### PR TITLE
Prepare v1.0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 1.0.13 – 2023-08-21
+
+### Changed
+
+- try to select gpt-3.5 when default model is not found when getting model list
+- use selected default llm (in admin settings ) in the translation provider
+
+### Fixed
+
+- remove dashboard category in info.xml
+- dynamically change labels depending if OpenAi or LocalAi is used
+
 ## 1.0.12 – 2023-08-04
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -78,7 +78,7 @@ Negative:
 
 Learn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud.com/blog/nextcloud-ethical-ai-rating/).
 ]]></description>
-    <version>1.0.12</version>
+    <version>1.0.13</version>
     <licence>agpl</licence>
     <author>Julien Veyssier</author>
     <namespace>OpenAi</namespace>


### PR DESCRIPTION
### Changed

- try to select gpt-3.5 when default model is not found when getting model list
- use selected default llm (in admin settings ) in the translation provider

### Fixed

- remove dashboard category in info.xml
- dynamically change labels depending if OpenAi or LocalAi is used