### PR TITLE
Add admin setting for choosing endpoint when using LocalAI

### DIFF
--- a/lib/Controller/OpenAiAPIController.php
+++ b/lib/Controller/OpenAiAPIController.php
@@ -89,8 +89,18 @@ class OpenAiAPIController extends Controller {
 		if ($model === null) {
 			$model = $this->openAiSettingsService->getUserDefaultCompletionModelId($this->userId);
 		}
+
+		$useChat = false;
+		if (!$this->openAiAPIService->isUsingOpenAi()) {
+			if ($this->openAiSettingsService->getChatEndpointEnabled()) {
+				$useChat = true;
+			}			
+		} else if (str_starts_with($model,'gpt-')) {
+			$useChat = true;
+		}
+
 		try {
-			if (str_starts_with($model, 'gpt-')) {
+			if ($useChat) {
 				$response = $this->openAiAPIService->createChatCompletion($this->userId, $prompt, $n, $model, $maxTokens);
 			} else {
 				$response = $this->openAiAPIService->createCompletion($this->userId, $prompt, $n, $model, $maxTokens);

--- a/lib/Controller/OpenAiAPIController.php
+++ b/lib/Controller/OpenAiAPIController.php
@@ -94,8 +94,8 @@ class OpenAiAPIController extends Controller {
 		if (!$this->openAiAPIService->isUsingOpenAi()) {
 			if ($this->openAiSettingsService->getChatEndpointEnabled()) {
 				$useChat = true;
-			}			
-		} else if (str_starts_with($model,'gpt-')) {
+			}
+		} elseif (str_starts_with($model, 'gpt-')) {
 			$useChat = true;
 		}
 

--- a/lib/Service/OpenAiAPIService.php
+++ b/lib/Service/OpenAiAPIService.php
@@ -300,7 +300,7 @@ class OpenAiAPIService {
 		if (isset($response['usage'])) {
 			$usage = $response['usage']['total_tokens'];
 			try {
-				$this->quotaUsageMapper->createQuotaUsage($userId, Application::QUOTA_TYPE_TEXT, $usage);
+				$this->quotaUsageMapper->createQuotaUsage($userId ?? '', Application::QUOTA_TYPE_TEXT, $usage);
 			} catch (DBException $e) {
 				$this->logger->warning('Could not create quota usage for user: ' . $userId . ' and quota type: ' . Application::QUOTA_TYPE_TEXT . '. Error: ' . $e->getMessage(), ['app' => Application::APP_ID]);
 			}
@@ -372,7 +372,7 @@ class OpenAiAPIService {
 			$usage = $response['usage']['total_tokens'];
 
 			try {
-				$this->quotaUsageMapper->createQuotaUsage($userId, Application::QUOTA_TYPE_TEXT, $usage);
+				$this->quotaUsageMapper->createQuotaUsage($userId ?? '', Application::QUOTA_TYPE_TEXT, $usage);
 			} catch (DBException $e) {
 				$this->logger->warning('Could not create quota usage for user: ' . $userId . ' and quota type: ' . Application::QUOTA_TYPE_TEXT . '. Error: ' . $e->getMessage(), ['app' => Application::APP_ID]);
 			}
@@ -479,7 +479,7 @@ class OpenAiAPIService {
 			$audioDuration = intval(round(floatval(array_pop($response['segments'])['end'])));
 
 			try {
-				$this->quotaUsageMapper->createQuotaUsage($userId, Application::QUOTA_TYPE_TRANSCRIPTION, $audioDuration);
+				$this->quotaUsageMapper->createQuotaUsage($userId ?? '', Application::QUOTA_TYPE_TRANSCRIPTION, $audioDuration);
 			} catch (DBException $e) {
 				$this->logger->warning('Could not create quota usage for user: ' . $userId . ' and quota type: ' . Application::QUOTA_TYPE_TRANSCRIPTION . '. Error: ' . $e->getMessage(), ['app' => Application::APP_ID]);
 			}
@@ -529,7 +529,7 @@ class OpenAiAPIService {
 			}
 
 			try {
-				$this->quotaUsageMapper->createQuotaUsage($userId, Application::QUOTA_TYPE_IMAGE, $n);
+				$this->quotaUsageMapper->createQuotaUsage($userId ?? '', Application::QUOTA_TYPE_IMAGE, $n);
 			} catch (DBException $e) {
 				$this->logger->warning('Could not create quota usage for user: ' . $userId . ' and quota type: ' . Application::QUOTA_TYPE_IMAGE . '. Error: ' . $e->getMessage(), ['app' => Application::APP_ID]);
 			}

--- a/lib/Service/OpenAiAPIService.php
+++ b/lib/Service/OpenAiAPIService.php
@@ -283,11 +283,13 @@ class OpenAiAPIService {
 
 		$params = [
 			'model' => $model,
-			'messages' => [['role' => 'user', 'content' => $prompt]],
+			'prompt' => $prompt,
 			'max_tokens' => $maxTokens,
 			'n' => $n,
 		];
-
+		if ($userId !== null) {
+			$params['user'] = $userId;
+		}
 		$response = $this->request($userId, 'completions', $params, 'POST');
 
 		if (!isset($response['choices'])) {
@@ -355,6 +357,9 @@ class OpenAiAPIService {
 			'max_tokens' => $maxTokens,
 			'n' => $n,
 		];
+		if ($userId !== null) {
+			$params['user'] = $userId;
+		}
 
 		$response = $this->request($userId, 'chat/completions', $params, 'POST');
 

--- a/lib/Service/OpenAiSettingsService.php
+++ b/lib/Service/OpenAiSettingsService.php
@@ -40,7 +40,8 @@ class OpenAiSettingsService {
 		'image_picker_enabled' => 'boolean',
 		'text_completion_picker_enabled' => 'boolean',
 		'translation_provider_enabled' => 'boolean',
-		'stt_provider_enabled' => 'boolean'
+		'stt_provider_enabled' => 'boolean',
+		'chat_endpoint_enabled' => 'boolean'
 	];
 
 	private const USER_CONFIG_TYPES = [
@@ -135,6 +136,13 @@ class OpenAiSettingsService {
 	}
 
 	/**
+	 * @return boolean
+	 */
+	public function getChatEndpointEnabled(): bool {
+		return $this->config->getAppValue(Application::APP_ID, 'chat_endpoint_enabled', '0') === '1';
+	}
+
+	/**
 	 * Get the admin config for the settings page
 	 * @return mixed[]
 	 */
@@ -154,7 +162,8 @@ class OpenAiSettingsService {
 			'image_picker_enabled' => $this->getImagePickerEnabled(),
 			'text_completion_picker_enabled' => $this->getTextCompletionPickerEnabled(),
 			'translation_provider_enabled' => $this->getTranslationProviderEnabled(),
-			'stt_provider_enabled' => $this->getSttProviderEnabled()
+			'stt_provider_enabled' => $this->getSttProviderEnabled(),
+			'chat_endpoint_enabled' => $this->getChatEndpointEnabled()
 		];
 	}
 
@@ -368,6 +377,9 @@ class OpenAiSettingsService {
 		if (isset($adminConfig['stt_provider_enabled'])) {
 			$this->setSttProviderEnabled($adminConfig['stt_provider_enabled']);
 		}
+		if (isset($adminConfig['chat_endpoint_enabled'])) {
+			$this->setChatEndpointEnabled($adminConfig['chat_endpoint_enabled']);
+		}
 
 	}
 
@@ -393,7 +405,6 @@ class OpenAiSettingsService {
 		}
 	}
 
-	// Setters and getters for missing settings
 	/**
 	 * @param bool $enabled
 	 * @return void
@@ -437,5 +448,12 @@ class OpenAiSettingsService {
 	 */
 	public function setLastImageSize(string $userId, string $imageSize): void {
 		$this->config->setUserValue($userId, Application::APP_ID, 'last_image_size', $imageSize);
+	}
+
+	/**
+	 * @param bool $enabled
+	 */
+	public function setChatEndpointEnabled(bool $enabled): void {
+		$this->config->setAppValue(Application::APP_ID, 'chat_endpoint_enabled', $enabled ? '1' : '0');
 	}
 }

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -22,6 +22,34 @@
 				<InformationOutlineIcon :size="20" class="icon" />
 				{{ t('integration_openai', 'This should be the address of your LocalAI instance from the point of view of your Nextcloud server. This can be a local address with a port like http://localhost:8080') }}
 			</p>
+			<div v-show="state.url !== ''" class="line">
+				<label>
+					<EarthIcon :size="20" class="icon" />
+					{{ t('integration_openai', 'Choose endpoint: ') }}
+				</label>
+				<input id="openai-chat-endpoint-yes"
+					v-model="state.chat_endpoint_enabled"
+					:value="true"
+					type="radio"
+					name="chat_endpoint"
+					@input="onInput">
+				<label for="openai-chat-endpoint-yes">
+					{{ t('integration_openai', 'Chat completions') }}
+				</label>
+				<input id="openai-chat-endpoint-no"
+					v-model="state.chat_endpoint_enabled"
+					:value="false"
+					type="radio"
+					name="chat_endpoint"
+					@input="onInput">
+				<label for="openai-chat-endpoint-no">
+					{{ t('integration_openai', 'Completions') }}
+				</label>
+			</div>
+			<p v-show="state.url !== ''" class="settings-hint">
+				<InformationOutlineIcon :size="20" class="icon" />
+				{{ t('integration_openai', 'Using the chat endpoint may improve text generation quality for "instruction following" fine-tuned models.') }}
+			</p>
 			<div class="line">
 				<label for="openai-api-key">
 					<KeyIcon :size="20" class="icon" />
@@ -324,6 +352,7 @@ export default {
 				this.saveOptions({
 					api_key: this.state.api_key,
 					url: this.state.url,
+					chat_endpoint_enabled: this.state.chat_endpoint_enabled,
 					request_timeout: this.state.request_timeout,
 					max_tokens: this.state.max_tokens,
 					quota_period: this.state.quota_period,
@@ -399,6 +428,9 @@ export default {
 		}
 		> input:invalid {
 			border-color: var(--color-error);
+		}
+		> input[type='radio'] {
+			width: auto;
 		}
 		.spacer {
 			display: inline-block;

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -187,10 +187,10 @@ export default {
 					)
 				})
 		},
-		clearPromptHistory(clearImages, clearText) {
+		clearPromptHistory(clearText, clearImages) {
 			const params = {
-				clearTextPrompts: clearImages,
-				clearImagePrompts: clearText,
+				clearTextPrompts: clearText,
+				clearImagePrompts: clearImages,
 			}
 			const url = generateUrl('/apps/integration_openai/clear-prompt-history')
 			return axios.post(url, params)

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -43,11 +43,11 @@
 					{{ t('integration_openai', 'Clear prompt history') }}
 				</label>
 				<button id="clear-text-prompt-history"
-					@click="clearPromptHistory(false,true)">
+					@click="clearPromptHistory(true, false)">
 					{{ t('integration_openai', 'Clear text prompts') }}
 				</button>
 				<button id="clear-image-prompt-history"
-					@click="clearPromptHistory(true,false)">
+					@click="clearPromptHistory(false, true)">
 					{{ t('integration_openai', 'Clear image prompts') }}
 				</button>
 			</div>


### PR DESCRIPTION
Exposes choosing the endpoint for the LocalAI as an admin setting. This should improve text generations quite a bit since the chat endpoint will inject the proper model specific prompt template at the LocalAI end.

Also, fixes the params for calling the plain "completions" endpoint: https://github.com/nextcloud/integration_openai/issues/60