### PR TITLE
Implement IProviderWithExpectedRuntime and IProviderWithUserId TP providers

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -71,7 +71,7 @@ Negative:
 
 Positive:
 * the software for training and inferencing of this model is open source
-* the trained model is freely available, and thus can be ran on-premises 
+* the trained model is freely available, and thus can be ran on-premises
 
 Negative:
 * the training data is not freely available, limiting the ability of external parties to check and correct for bias or optimise the model’s performance and CO2 usage.
@@ -93,7 +93,7 @@ Learn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud
     <screenshot>https://github.com/nextcloud/integration_openai/raw/main/img/screenshot3.jpg</screenshot>
     <screenshot>https://github.com/nextcloud/integration_openai/raw/main/img/screenshot4.jpg</screenshot>
     <dependencies>
-        <nextcloud min-version="27.1.0" max-version="28"/>
+        <nextcloud min-version="28" max-version="29"/>
     </dependencies>
     <background-jobs>
 		<job>OCA\OpenAi\Cron\CleanupImageGenerations</job>

--- a/lib/TextProcessing/FreePromptProvider.php
+++ b/lib/TextProcessing/FreePromptProvider.php
@@ -10,10 +10,11 @@ use OCA\OpenAi\Service\OpenAiAPIService;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\TextProcessing\FreePromptTaskType;
-use OCP\TextProcessing\IProvider;
+use OCP\TextProcessing\IProviderWithExpectedRuntime;
+use OCP\TextProcessing\IProviderWithUserId;
 use RunTimeException;
 
-class FreePromptProvider implements IProvider {
+class FreePromptProvider implements IProviderWithExpectedRuntime, IProviderWithUserId {
 	public function __construct(
 		private OpenAiAPIService $openAiAPIService,
 		private IConfig $config,
@@ -45,5 +46,15 @@ class FreePromptProvider implements IProvider {
 
 	public function getTaskType(): string {
 		return FreePromptTaskType::class;
+	}
+
+	public function getExpectedRuntime(): int {
+		return $this->openAiAPIService->isUsingOpenAi()
+			? 10
+			: 60 * 5;
+	}
+
+	public function setUserId(?string $userId): void {
+		$this->userId = $userId;
 	}
 }

--- a/lib/TextProcessing/HeadlineProvider.php
+++ b/lib/TextProcessing/HeadlineProvider.php
@@ -10,10 +10,11 @@ use OCA\OpenAi\Service\OpenAiAPIService;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\TextProcessing\HeadlineTaskType;
-use OCP\TextProcessing\IProvider;
+use OCP\TextProcessing\IProviderWithExpectedRuntime;
+use OCP\TextProcessing\IProviderWithUserId;
 use RuntimeException;
 
-class HeadlineProvider implements IProvider {
+class HeadlineProvider implements IProviderWithExpectedRuntime, IProviderWithUserId {
 	public function __construct(
 		private OpenAiAPIService $openAiAPIService,
 		private IConfig $config,
@@ -46,5 +47,15 @@ class HeadlineProvider implements IProvider {
 
 	public function getTaskType(): string {
 		return HeadlineTaskType::class;
+	}
+
+	public function getExpectedRuntime(): int {
+		return $this->openAiAPIService->isUsingOpenAi()
+			? 10
+			: 60 * 5;
+	}
+
+	public function setUserId(?string $userId): void {
+		$this->userId = $userId;
 	}
 }

--- a/lib/TextProcessing/ReformulateProvider.php
+++ b/lib/TextProcessing/ReformulateProvider.php
@@ -9,10 +9,11 @@ use OCA\OpenAi\AppInfo\Application;
 use OCA\OpenAi\Service\OpenAiAPIService;
 use OCP\IConfig;
 use OCP\IL10N;
-use OCP\TextProcessing\IProvider;
+use OCP\TextProcessing\IProviderWithExpectedRuntime;
+use OCP\TextProcessing\IProviderWithUserId;
 use RuntimeException;
 
-class ReformulateProvider implements IProvider {
+class ReformulateProvider implements IProviderWithExpectedRuntime, IProviderWithUserId {
 	public function __construct(
 		private OpenAiAPIService $openAiAPIService,
 		private IConfig $config,
@@ -45,5 +46,15 @@ class ReformulateProvider implements IProvider {
 
 	public function getTaskType(): string {
 		return ReformulateTaskType::class;
+	}
+
+	public function getExpectedRuntime(): int {
+		return $this->openAiAPIService->isUsingOpenAi()
+			? 10
+			: 60 * 5;
+	}
+
+	public function setUserId(?string $userId): void {
+		$this->userId = $userId;
 	}
 }

--- a/lib/TextProcessing/SummaryProvider.php
+++ b/lib/TextProcessing/SummaryProvider.php
@@ -9,11 +9,12 @@ use OCA\OpenAi\AppInfo\Application;
 use OCA\OpenAi\Service\OpenAiAPIService;
 use OCP\IConfig;
 use OCP\IL10N;
-use OCP\TextProcessing\IProvider;
+use OCP\TextProcessing\IProviderWithExpectedRuntime;
+use OCP\TextProcessing\IProviderWithUserId;
 use OCP\TextProcessing\SummaryTaskType;
 use RuntimeException;
 
-class SummaryProvider implements IProvider {
+class SummaryProvider implements IProviderWithExpectedRuntime, IProviderWithUserId {
 	public function __construct(
 		private OpenAiAPIService $openAiAPIService,
 		private IConfig $config,
@@ -49,5 +50,15 @@ class SummaryProvider implements IProvider {
 
 	public function getTaskType(): string {
 		return SummaryTaskType::class;
+	}
+
+	public function getExpectedRuntime(): int {
+		return $this->openAiAPIService->isUsingOpenAi()
+			? 10
+			: 60 * 5;
+	}
+
+	public function setUserId(?string $userId): void {
+		$this->userId = $userId;
 	}
 }


### PR DESCRIPTION
* Bump min NC version to 28 (when the new interfaces appeared
* Bump max NC version to 29 (not necessary but why not)
* Set an expected time of 10 seconds if OpenAI is used and 5 minutes if LocalAI is used

@marcelklehr Is it fine if `setUserId` overwrites the injected value in the class attribute?