### PR TITLE
Allow local IP address for LocalAI

### DIFF
--- a/lib/Service/OpenAiAPIService.php
+++ b/lib/Service/OpenAiAPIService.php
@@ -663,6 +663,10 @@ class OpenAiAPIService {
 				}
 			}
 
+			if (!$this->isUsingOpenAi()) {
+				$options["nextcloud"]["allow_local_address"] = true;
+			}
+			
 			if ($contentType === null) {
 				$options['headers']['Content-Type'] = 'application/json';
 			} elseif ($contentType === 'multipart/form-data') {

--- a/lib/Service/OpenAiAPIService.php
+++ b/lib/Service/OpenAiAPIService.php
@@ -664,7 +664,7 @@ class OpenAiAPIService {
 			}
 
 			if (!$this->isUsingOpenAi()) {
-				$options["nextcloud"]["allow_local_address"] = true;
+				$options['nextcloud']['allow_local_address'] = true;
 			}
 			
 			if ($contentType === null) {

--- a/tests/unit/Controller/OpenAiControllerTest.php
+++ b/tests/unit/Controller/OpenAiControllerTest.php
@@ -448,7 +448,11 @@ class OpenAiControllerTest extends TestCase {
           }';
 
 		$url = $url_base . '/v1/completions';
-		$options = ['timeout' => Application::OPENAI_DEFAULT_REQUEST_TIMEOUT, 'headers' => ['User-Agent' => 'Nextcloud OpenAI integration', 'Authorization' => 'Bearer This is a PHPUnit test API key', 'Content-Type' => 'application/json']];
+		$options = [
+			'nextcloud' => ['allow_local_address' => true],
+			'timeout' => Application::OPENAI_DEFAULT_REQUEST_TIMEOUT, 
+			'headers' => ['User-Agent' => 'Nextcloud OpenAI integration', 'Authorization' => 'Bearer This is a PHPUnit test API key', 'Content-Type' => 'application/json'],
+		];
 		$options['body'] = json_encode(['model' => 'test_model', 'prompt' => $prompt, 'max_tokens' => $maxTokens, 'n' => $n, 'user' => self::TEST_USER1]);
 
 		$iResponse = $this->createMock(\OCP\Http\Client\IResponse::class);
@@ -507,7 +511,11 @@ class OpenAiControllerTest extends TestCase {
 		  }';
 
 		$url = $url_base . '/v1/chat/completions';
-		$options = ['timeout' => Application::OPENAI_DEFAULT_REQUEST_TIMEOUT, 'headers' => ['User-Agent' => 'Nextcloud OpenAI integration', 'Authorization' => 'Bearer This is a PHPUnit test API key', 'Content-Type' => 'application/json']];
+		$options = [
+			'nextcloud' => ['allow_local_address' => true],
+			'timeout' => Application::OPENAI_DEFAULT_REQUEST_TIMEOUT, 
+			'headers' => ['User-Agent' => 'Nextcloud OpenAI integration', 'Authorization' => 'Bearer This is a PHPUnit test API key', 'Content-Type' => 'application/json'],
+		];
 		$options['body'] = json_encode(['model' => 'test_model', 'messages' => [['role' => 'user', 'content' => $prompt]], 'max_tokens' => $maxTokens, 'n' => $n, 'user' => self::TEST_USER1]);
 
 		$iResponse = $this->createMock(\OCP\Http\Client\IResponse::class);
@@ -568,7 +576,11 @@ class OpenAiControllerTest extends TestCase {
 		  }';
 
 		$url = $url_base . '/v1/chat/completions';
-		$options = ['timeout' => Application::OPENAI_DEFAULT_REQUEST_TIMEOUT, 'headers' => ['User-Agent' => 'Nextcloud OpenAI integration', 'Authorization' => 'Basic ' . base64_encode('testuser:testpassword'), 'Content-Type' => 'application/json']];
+		$options = [
+			'nextcloud' => ['allow_local_address' => true],
+			'timeout' => Application::OPENAI_DEFAULT_REQUEST_TIMEOUT, 
+			'headers' => ['User-Agent' => 'Nextcloud OpenAI integration', 'Authorization' => 'Basic ' . base64_encode('testuser:testpassword'), 'Content-Type' => 'application/json'],
+		];
 		$options['body'] = json_encode(['model' => 'test_model', 'messages' => [['role' => 'user', 'content' => $prompt]], 'max_tokens' => $maxTokens, 'n' => $n, 'user' => self::TEST_USER1]);
 
 		$iResponse = $this->createMock(\OCP\Http\Client\IResponse::class);


### PR DESCRIPTION
So far, to use LocalAI, one had to set `"allow_local_remote_servers": true` in `config.php`. 

However, I think this should not be a requirement for a service that is meant to run in the local network?

This PR adjusts the request to allow local addresses when using LocalAI, without a need to allow requests to local addresses for all other apps.