### PR TITLE
Use lp-filtering to estimate expected runtime

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -42,6 +42,12 @@ class Application extends App implements IBootstrap {
 	public const DEFAULT_MAX_NUM_OF_TOKENS = 1000;
 	public const DEFAULT_QUOTA_PERIOD = 30;
 
+	public const DEFAULT_OPENAI_TEXT_GENERATION_TIME = 10; // seconds
+	public const DEFAULT_LOCALAI_TEXT_GENERATION_TIME = 60; // seconds
+	public const DEFAULT_OPENAI_IMAGE_GENERATION_TIME = 20; // seconds
+	public const DEFAULT_LOCALAI_IMAGE_GENERATION_TIME = 90; // seconds
+	public const EXPECTED_RUNTIME_LOWPASS_FACTOR = 0.1;
+
 	public const QUOTA_TYPE_TEXT = 0;
 	public const QUOTA_TYPE_IMAGE = 1;
 	public const QUOTA_TYPE_TRANSCRIPTION = 2;

--- a/lib/Service/OpenAiAPIService.php
+++ b/lib/Service/OpenAiAPIService.php
@@ -639,12 +639,12 @@ class OpenAiAPIService {
 	 */
 	public function updateExpTextProcessingTime(int $runtime): void {
 		$oldTime = $this->getExpTextProcessingTime();
-		$newTime = intval((1 - Application::EXPECTED_RUNTIME_LOWPASS_FACTOR) * $oldTime + Application::EXPECTED_RUNTIME_LOWPASS_FACTOR * $runtime);
+		$newTime = (1 - Application::EXPECTED_RUNTIME_LOWPASS_FACTOR) * $oldTime + Application::EXPECTED_RUNTIME_LOWPASS_FACTOR * $runtime;
 
 		if ($this->isUsingOpenAi()) {
-			$this->config->setAppValue(Application::APP_ID, 'openai_text_generation_time', strval($newTime));
+			$this->config->setAppValue(Application::APP_ID, 'openai_text_generation_time', strval(intval($newTime)));
 		} else {
-			$this->config->setAppValue(Application::APP_ID, 'localai_text_generation_time', strval($newTime));
+			$this->config->setAppValue(Application::APP_ID, 'localai_text_generation_time', strval(intval($newTime)));
 		}
 	}
 
@@ -663,12 +663,12 @@ class OpenAiAPIService {
 	 */
 	public function updateExpImgProcessingTime(int $runtime): void {
 		$oldTime = $this->getExpImgProcessingTime();
-		$newTime = intval((1 - Application::EXPECTED_RUNTIME_LOWPASS_FACTOR) * $oldTime + Application::EXPECTED_RUNTIME_LOWPASS_FACTOR * $runtime);
+		$newTime = (1 - Application::EXPECTED_RUNTIME_LOWPASS_FACTOR) * $oldTime + Application::EXPECTED_RUNTIME_LOWPASS_FACTOR * $runtime;
 
 		if ($this->isUsingOpenAi()) {
-			$this->config->setAppValue(Application::APP_ID, 'openai_image_generation_time', strval($newTime));
+			$this->config->setAppValue(Application::APP_ID, 'openai_image_generation_time', strval(intval($newTime)));
 		} else {
-			$this->config->setAppValue(Application::APP_ID, 'localai_image_generation_time', strval($newTime));
+			$this->config->setAppValue(Application::APP_ID, 'localai_image_generation_time', strval(intval($newTime)));
 		}
 	}
 

--- a/lib/Service/OpenAiAPIService.php
+++ b/lib/Service/OpenAiAPIService.php
@@ -625,6 +625,54 @@ class OpenAiAPIService {
 	}
 
 	/**
+	 * @return int
+	 */
+	public function getExpTextProcessingTime(): int {
+		return $this->isUsingOpenAi()
+			? intval($this->config->getAppValue(Application::APP_ID, 'openai_text_generation_time', strval(Application::DEFAULT_OPENAI_TEXT_GENERATION_TIME)))
+			: intval($this->config->getAppValue(Application::APP_ID, 'localai_text_generation_time', strval(Application::DEFAULT_LOCALAI_TEXT_GENERATION_TIME)));
+	}
+
+	/**
+	 * @param int $runtime
+	 * @return void
+	 */
+	public function updateExpTextProcessingTime(int $runtime): void {
+		$oldTime = $this->getExpTextProcessingTime();
+		$newTime = intval((1 - Application::EXPECTED_RUNTIME_LOWPASS_FACTOR) * $oldTime + Application::EXPECTED_RUNTIME_LOWPASS_FACTOR * $runtime);
+
+		if ($this->isUsingOpenAi()) {
+			$this->config->setAppValue(Application::APP_ID, 'openai_text_generation_time', strval($newTime));
+		} else {
+			$this->config->setAppValue(Application::APP_ID, 'localai_text_generation_time', strval($newTime));
+		}
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getExpImgProcessingTime(): int {
+		return $this->isUsingOpenAi()
+			? intval($this->config->getAppValue(Application::APP_ID, 'openai_image_generation_time', strval(Application::DEFAULT_OPENAI_IMAGE_GENERATION_TIME)))
+			: intval($this->config->getAppValue(Application::APP_ID, 'localai_image_generation_time', strval(Application::DEFAULT_LOCALAI_IMAGE_GENERATION_TIME)));
+	}
+
+	/**
+	 * @param int $runtime
+	 * @return void
+	 */
+	public function updateExpImgProcessingTime(int $runtime): void {
+		$oldTime = $this->getExpImgProcessingTime();
+		$newTime = intval((1 - Application::EXPECTED_RUNTIME_LOWPASS_FACTOR) * $oldTime + Application::EXPECTED_RUNTIME_LOWPASS_FACTOR * $runtime);
+
+		if ($this->isUsingOpenAi()) {
+			$this->config->setAppValue(Application::APP_ID, 'openai_image_generation_time', strval($newTime));
+		} else {
+			$this->config->setAppValue(Application::APP_ID, 'localai_image_generation_time', strval($newTime));
+		}
+	}
+
+	/**
 	 * Make an HTTP request to the OpenAI API
 	 * @param string|null $userId
 	 * @param string $endPoint The path to reach

--- a/lib/TextProcessing/FreePromptProvider.php
+++ b/lib/TextProcessing/FreePromptProvider.php
@@ -32,17 +32,6 @@ class FreePromptProvider implements IProviderWithExpectedRuntime, IProviderWithU
 			: $this->l10n->t('LocalAI integration');
 	}
 
-	private function updateExpectedRuntime(int $runtime): void {
-		$oldTime = $this->getExpectedRuntime();
-		$newTime = intval((1 - Application::EXPECTED_RUNTIME_LOWPASS_FACTOR) * $oldTime + Application::EXPECTED_RUNTIME_LOWPASS_FACTOR * $runtime);
-
-		if ($this->openAiAPIService->isUsingOpenAi()) {
-			$this->config->setAppValue(Application::APP_ID, 'openai_text_generation_time', strval($newTime));
-		} else {
-			$this->config->setAppValue(Application::APP_ID, 'localai_text_generation_time', strval($newTime));
-		}
-	}
-
 	public function process(string $prompt): string {
 		$startTime = time();
 		$adminModel = $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_COMPLETION_MODEL_ID) ?: Application::DEFAULT_COMPLETION_MODEL_ID;
@@ -58,7 +47,7 @@ class FreePromptProvider implements IProviderWithExpectedRuntime, IProviderWithU
 		}
 		if (count($completion) > 0) {
 			$endTime = time();
-			$this->updateExpectedRuntime($endTime - $startTime);
+			$this->openAiAPIService->updateExpTextProcessingTime($endTime - $startTime);
 			return array_pop($completion);
 		}
 		
@@ -70,9 +59,7 @@ class FreePromptProvider implements IProviderWithExpectedRuntime, IProviderWithU
 	}
 
 	public function getExpectedRuntime(): int {
-		return $this->openAiAPIService->isUsingOpenAi()
-			? intval($this->config->getAppValue(Application::APP_ID, 'openai_text_generation_time', strval(Application::DEFAULT_OPENAI_TEXT_GENERATION_TIME)))
-			: intval($this->config->getAppValue(Application::APP_ID, 'localai_text_generation_time', strval(Application::DEFAULT_LOCALAI_TEXT_GENERATION_TIME)));
+		return $this->openAiAPIService->getExpTextProcessingTime();
 	}
 
 	public function setUserId(?string $userId): void {

--- a/lib/TextProcessing/FreePromptProvider.php
+++ b/lib/TextProcessing/FreePromptProvider.php
@@ -50,7 +50,7 @@ class FreePromptProvider implements IProviderWithExpectedRuntime, IProviderWithU
 			$this->openAiAPIService->updateExpTextProcessingTime($endTime - $startTime);
 			return array_pop($completion);
 		}
-		
+
 		throw new RunTimeException('No result in OpenAI/LocalAI response.');
 	}
 

--- a/lib/TextProcessing/HeadlineProvider.php
+++ b/lib/TextProcessing/HeadlineProvider.php
@@ -31,17 +31,6 @@ class HeadlineProvider implements IProviderWithExpectedRuntime, IProviderWithUse
 			: $this->l10n->t('LocalAI integration');
 	}
 
-	private function updateExpectedRuntime(int $runtime): void {
-		$oldTime = $this->getExpectedRuntime();
-		$newTime = intval((1 - Application::EXPECTED_RUNTIME_LOWPASS_FACTOR) * $oldTime + Application::EXPECTED_RUNTIME_LOWPASS_FACTOR * $runtime);
-
-		if ($this->openAiAPIService->isUsingOpenAi()) {
-			$this->config->setAppValue(Application::APP_ID, 'openai_text_generation_time', strval($newTime));
-		} else {
-			$this->config->setAppValue(Application::APP_ID, 'localai_text_generation_time', strval($newTime));
-		}
-	}
-
 	public function process(string $prompt): string {
 		$startTime = time();
 		$adminModel = $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_COMPLETION_MODEL_ID) ?: Application::DEFAULT_COMPLETION_MODEL_ID;
@@ -58,7 +47,7 @@ class HeadlineProvider implements IProviderWithExpectedRuntime, IProviderWithUse
 		}
 		if (count($completion) > 0) {
 			$endTime = time();
-			$this->updateExpectedRuntime($endTime - $startTime);
+			$this->openAiAPIService->updateExpTextProcessingTime($endTime - $startTime);
 			return array_pop($completion);
 		}
 
@@ -70,9 +59,7 @@ class HeadlineProvider implements IProviderWithExpectedRuntime, IProviderWithUse
 	}
 
 	public function getExpectedRuntime(): int {
-		return $this->openAiAPIService->isUsingOpenAi()
-			? intval($this->config->getAppValue(Application::APP_ID, 'openai_text_generation_time', strval(Application::DEFAULT_OPENAI_TEXT_GENERATION_TIME)))
-			: intval($this->config->getAppValue(Application::APP_ID, 'localai_text_generation_time', strval(Application::DEFAULT_LOCALAI_TEXT_GENERATION_TIME)));
+		return $this->openAiAPIService->getExpTextProcessingTime();
 	}
 
 	public function setUserId(?string $userId): void {

--- a/lib/TextProcessing/HeadlineProvider.php
+++ b/lib/TextProcessing/HeadlineProvider.php
@@ -31,7 +31,19 @@ class HeadlineProvider implements IProviderWithExpectedRuntime, IProviderWithUse
 			: $this->l10n->t('LocalAI integration');
 	}
 
+	private function updateExpectedRuntime(int $runtime): void {
+		$oldTime = $this->getExpectedRuntime();
+		$newTime = intval((1 - Application::EXPECTED_RUNTIME_LOWPASS_FACTOR) * $oldTime + Application::EXPECTED_RUNTIME_LOWPASS_FACTOR * $runtime);
+
+		if ($this->openAiAPIService->isUsingOpenAi()) {
+			$this->config->setAppValue(Application::APP_ID, 'openai_text_generation_time', strval($newTime));
+		} else {
+			$this->config->setAppValue(Application::APP_ID, 'localai_text_generation_time', strval($newTime));
+		}
+	}
+
 	public function process(string $prompt): string {
+		$startTime = time();
 		$adminModel = $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_COMPLETION_MODEL_ID) ?: Application::DEFAULT_COMPLETION_MODEL_ID;
 		$prompt = 'Give me the headline of the following text:' . "\n\n" . $prompt;
 		// Max tokens are limited later to max tokens specified in the admin settings so here we just request PHP_INT_MAX
@@ -45,6 +57,8 @@ class HeadlineProvider implements IProviderWithExpectedRuntime, IProviderWithUse
 			throw new RunTimeException('OpenAI/LocalAI request failed: ' . $e->getMessage());
 		}
 		if (count($completion) > 0) {
+			$endTime = time();
+			$this->updateExpectedRuntime($endTime - $startTime);
 			return array_pop($completion);
 		}
 
@@ -57,8 +71,8 @@ class HeadlineProvider implements IProviderWithExpectedRuntime, IProviderWithUse
 
 	public function getExpectedRuntime(): int {
 		return $this->openAiAPIService->isUsingOpenAi()
-			? 10
-			: 60 * 5;
+			? intval($this->config->getAppValue(Application::APP_ID, 'openai_text_generation_time', strval(Application::DEFAULT_OPENAI_TEXT_GENERATION_TIME)))
+			: intval($this->config->getAppValue(Application::APP_ID, 'localai_text_generation_time', strval(Application::DEFAULT_LOCALAI_TEXT_GENERATION_TIME)));
 	}
 
 	public function setUserId(?string $userId): void {

--- a/lib/TextProcessing/ReformulateProvider.php
+++ b/lib/TextProcessing/ReformulateProvider.php
@@ -30,17 +30,6 @@ class ReformulateProvider implements IProviderWithExpectedRuntime, IProviderWith
 			: $this->l10n->t('LocalAI integration');
 	}
 
-	private function updateExpectedRuntime(int $runtime): void {
-		$oldTime = $this->getExpectedRuntime();
-		$newTime = intval((1 - Application::EXPECTED_RUNTIME_LOWPASS_FACTOR) * $oldTime + Application::EXPECTED_RUNTIME_LOWPASS_FACTOR * $runtime);
-
-		if ($this->openAiAPIService->isUsingOpenAi()) {
-			$this->config->setAppValue(Application::APP_ID, 'openai_text_generation_time', strval($newTime));
-		} else {
-			$this->config->setAppValue(Application::APP_ID, 'localai_text_generation_time', strval($newTime));
-		}
-	}
-
 	public function process(string $prompt): string {
 		$startTime = time();
 		$adminModel = $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_COMPLETION_MODEL_ID) ?: Application::DEFAULT_COMPLETION_MODEL_ID;
@@ -57,7 +46,7 @@ class ReformulateProvider implements IProviderWithExpectedRuntime, IProviderWith
 		}
 		if (count($completion) > 0) {
 			$endTime = time();
-			$this->updateExpectedRuntime($endTime - $startTime);
+			$this->openAiAPIService->updateExpTextProcessingTime($endTime - $startTime);
 			return array_pop($completion);
 		}
 
@@ -69,9 +58,7 @@ class ReformulateProvider implements IProviderWithExpectedRuntime, IProviderWith
 	}
 
 	public function getExpectedRuntime(): int {
-		return $this->openAiAPIService->isUsingOpenAi()
-			? intval($this->config->getAppValue(Application::APP_ID, 'openai_text_generation_time', strval(Application::DEFAULT_OPENAI_TEXT_GENERATION_TIME)))
-			: intval($this->config->getAppValue(Application::APP_ID, 'localai_text_generation_time', strval(Application::DEFAULT_LOCALAI_TEXT_GENERATION_TIME)));
+		return $this->openAiAPIService->getExpTextProcessingTime();
 	}
 
 	public function setUserId(?string $userId): void {

--- a/tests/unit/Controller/OpenAiControllerTest.php
+++ b/tests/unit/Controller/OpenAiControllerTest.php
@@ -24,7 +24,6 @@ use OCP\Http\Client\IClientService;
 use OCP\IConfig;
 use Test\TestCase;
 
-
 /**
  * @group DB
  */


### PR DESCRIPTION
Adds low-pass filtering for the expected runtime based on observed runtimes so that the consumers of the providers can have a more accurate estimate of the runtime.