### PR TITLE
Fix: use basic auth to get generated images if necessary

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -34,6 +34,7 @@ class Application extends App implements IBootstrap {
 
 	public const OPENAI_API_BASE_URL = 'https://api.openai.com';
 	public const OPENAI_DEFAULT_REQUEST_TIMEOUT = 60 * 4;
+	public const USER_AGENT = 'Nextcloud OpenAI/LocalAI integration';
 
 	public const DEFAULT_COMPLETION_MODEL_ID = 'gpt-3.5-turbo';
 	public const DEFAULT_TRANSCRIPTION_MODEL_ID = 'whisper-1';

--- a/lib/Controller/OpenAiAPIController.php
+++ b/lib/Controller/OpenAiAPIController.php
@@ -159,7 +159,7 @@ class OpenAiAPIController extends Controller {
 	#[NoCSRFRequired]
 	public function getImageGenerationContent(string $hash, int $urlId): DataDisplayResponse {
 		try {
-			$image = $this->openAiAPIService->getGenerationImage($hash, $urlId);
+			$image = $this->openAiAPIService->getGenerationImage($this->userId, $hash, $urlId);
 		} catch (Exception $e) {
 			$code = $e->getCode() === 0 ? Http::STATUS_BAD_REQUEST : intval($e->getCode());
 			return new DataDisplayResponse('', $code);
@@ -232,7 +232,7 @@ class OpenAiAPIController extends Controller {
 			$code = $e->getCode() === 0 ? Http::STATUS_BAD_REQUEST : intval($e->getCode());
 			return new DataResponse(['error' => $e->getMessage()], $code);
 		}
-		
+
 		return new DataResponse($info);
 	}
 

--- a/lib/Service/OpenAiAPIService.php
+++ b/lib/Service/OpenAiAPIService.php
@@ -636,7 +636,7 @@ class OpenAiAPIService {
 		$requestOptions = [
 			'timeout' => $timeout,
 			'headers' => [
-				'User-Agent' => 'Nextcloud OpenAI/LocalAI integration',
+				'User-Agent' => Application::USER_AGENT,
 			],
 		];
 
@@ -722,7 +722,7 @@ class OpenAiAPIService {
 			$options = [
 				'timeout' => $timeout,
 				'headers' => [
-					'User-Agent' => 'Nextcloud OpenAI/LocalAI integration',
+					'User-Agent' => Application::USER_AGENT,
 				],
 			];
 

--- a/lib/Service/OpenAiAPIService.php
+++ b/lib/Service/OpenAiAPIService.php
@@ -641,7 +641,7 @@ class OpenAiAPIService {
 		];
 
 		$useBasicAuth = $this->openAiSettingsService->getUseBasicAuth();
-		if ($useBasicAuth) {
+		if ($useBasicAuth && !$this->isUsingOpenAi()) {
 			$basicUser = $this->openAiSettingsService->getUserBasicUser($userId, true);
 			$basicPassword = $this->openAiSettingsService->getUserBasicPassword($userId, true);
 			if ($basicUser !== '' && $basicPassword !== '') {

--- a/lib/TextProcessing/FreePromptProvider.php
+++ b/lib/TextProcessing/FreePromptProvider.php
@@ -20,7 +20,7 @@ use RuntimeException;
  * @template-implements IProviderWithUserId<FreePromptTaskType>
  */
 class FreePromptProvider implements IProviderWithExpectedRuntime, IProviderWithUserId {
-	
+
 	public function __construct(
 		private OpenAiAPIService $openAiAPIService,
 		private IConfig $config,

--- a/lib/TextToImage/TextToImageProvider.php
+++ b/lib/TextToImage/TextToImageProvider.php
@@ -8,6 +8,7 @@ namespace OCA\OpenAi\TextToImage;
 
 use OCA\OpenAi\AppInfo\Application;
 use OCA\OpenAi\Service\OpenAiAPIService;
+use OCA\OpenAi\Service\OpenAiSettingsService;
 use OCP\Http\Client\IClientService;
 use OCP\IConfig;
 use OCP\IL10N;
@@ -17,6 +18,7 @@ use Psr\Log\LoggerInterface;
 class TextToImageProvider implements IProvider {
 	public function __construct(
 		private OpenAiAPIService $openAiAPIService,
+		private OpenAiSettingsService $openAiSettingsService,
 		private LoggerInterface $logger,
 		private IL10N $l,
 		private IClientService $clientService,
@@ -57,12 +59,13 @@ class TextToImageProvider implements IProvider {
 				throw new \RuntimeException('OpenAI/LocalAI\'s text to image generation failed: no image returned');
 			}
 			$client = $this->clientService->newClient();
+			$requestOptions = $this->openAiAPIService->getImageRequestOptions($this->userId);
 			// just in case $resources is not 0-based indexed, we know $urls is
 			$i = 0;
 			foreach ($resources as $resource) {
 				if (isset($urls[$i])) {
 					$url = $urls[$i];
-					$imageResponse = $client->get($url);
+					$imageResponse = $client->get($url, $requestOptions);
 					fwrite($resource, $imageResponse->getBody());
 				}
 				$i++;

--- a/tests/unit/Controller/OpenAiControllerTest.php
+++ b/tests/unit/Controller/OpenAiControllerTest.php
@@ -31,6 +31,7 @@ class OpenAiControllerTest extends TestCase {
 	public const APP_NAME = 'integration_openai';
 	public const TEST_USER1 = 'testuser';
 	public const OPENAI_API_BASE = 'https://api.openai.com/v1/';
+	public const AUTHORIZATION_HEADER = 'Bearer This is a PHPUnit test API key';
 
 	private $openAiApiController;
 	private $openAiApiService;
@@ -92,7 +93,7 @@ class OpenAiControllerTest extends TestCase {
 		} catch (\OCP\Db\Exception | \Exception | \Throwable $e) {
 			// Ignore
 		}
-		
+
 		// Delete quota usage for test user
 		$quotaUsageMapper = \OC::$server->get(QuotaUsageMapper::class);
 		try {
@@ -143,7 +144,7 @@ class OpenAiControllerTest extends TestCase {
           }';
 
 		$url = self::OPENAI_API_BASE . 'models';
-		$options = ['timeout' => Application::OPENAI_DEFAULT_REQUEST_TIMEOUT, 'headers' => ['User-Agent' => 'Nextcloud OpenAI integration', 'Authorization' => 'Bearer This is a PHPUnit test API key', 'Content-Type' => 'application/json']];
+		$options = ['timeout' => Application::OPENAI_DEFAULT_REQUEST_TIMEOUT, 'headers' => ['User-Agent' => Application::USER_AGENT, 'Authorization' => self::AUTHORIZATION_HEADER, 'Content-Type' => 'application/json']];
 
 		$iResponse = $this->createMock(\OCP\Http\Client\IResponse::class);
 		$iResponse->method('getBody')->willReturn($response);
@@ -188,7 +189,7 @@ class OpenAiControllerTest extends TestCase {
           }';
 
 		$url = self::OPENAI_API_BASE . 'completions';
-		$options = ['timeout' => Application::OPENAI_DEFAULT_REQUEST_TIMEOUT, 'headers' => ['User-Agent' => 'Nextcloud OpenAI integration', 'Authorization' => 'Bearer This is a PHPUnit test API key', 'Content-Type' => 'application/json']];
+		$options = ['timeout' => Application::OPENAI_DEFAULT_REQUEST_TIMEOUT, 'headers' => ['User-Agent' => Application::USER_AGENT, 'Authorization' => self::AUTHORIZATION_HEADER, 'Content-Type' => 'application/json']];
 		$options['body'] = json_encode(['model' => 'test_model', 'prompt' => $prompt, 'max_tokens' => $maxTokens, 'n' => $n, 'user' => self::TEST_USER1]);
 
 		$iResponse = $this->createMock(\OCP\Http\Client\IResponse::class);
@@ -242,7 +243,7 @@ class OpenAiControllerTest extends TestCase {
 		  }';
 
 		$url = self::OPENAI_API_BASE . 'chat/completions';
-		$options = ['timeout' => Application::OPENAI_DEFAULT_REQUEST_TIMEOUT, 'headers' => ['User-Agent' => 'Nextcloud OpenAI integration', 'Authorization' => 'Bearer This is a PHPUnit test API key', 'Content-Type' => 'application/json']];
+		$options = ['timeout' => Application::OPENAI_DEFAULT_REQUEST_TIMEOUT, 'headers' => ['User-Agent' => Application::USER_AGENT, 'Authorization' => self::AUTHORIZATION_HEADER, 'Content-Type' => 'application/json']];
 		$options['body'] = json_encode(['model' => $model, 'messages' => [['role' => 'user', 'content' => $prompt]], 'max_tokens' => $maxTokens, 'n' => $n, 'user' => self::TEST_USER1]);
 
 		$iResponse = $this->createMock(\OCP\Http\Client\IResponse::class);
@@ -331,7 +332,7 @@ class OpenAiControllerTest extends TestCase {
 		}';
 
 		$url = self::OPENAI_API_BASE . 'audio/translations';
-		$options = ['timeout' => Application::OPENAI_DEFAULT_REQUEST_TIMEOUT, 'headers' => ['User-Agent' => 'Nextcloud OpenAI integration', 'Authorization' => 'Bearer This is a PHPUnit test API key']];
+		$options = ['timeout' => Application::OPENAI_DEFAULT_REQUEST_TIMEOUT, 'headers' => ['User-Agent' => Application::USER_AGENT, 'Authorization' => self::AUTHORIZATION_HEADER]];
 		$options['multipart'] = [
 			[
 				'name' => 'model',
@@ -388,9 +389,9 @@ class OpenAiControllerTest extends TestCase {
 			  }
 			]
 		  }';
-		  
+
 		$url = self::OPENAI_API_BASE . 'images/generations';
-		$options = ['timeout' => Application::OPENAI_DEFAULT_REQUEST_TIMEOUT, 'headers' => ['User-Agent' => 'Nextcloud OpenAI integration', 'Authorization' => 'Bearer This is a PHPUnit test API key', 'Content-Type' => 'application/json']];
+		$options = ['timeout' => Application::OPENAI_DEFAULT_REQUEST_TIMEOUT, 'headers' => ['User-Agent' => Application::USER_AGENT, 'Authorization' => self::AUTHORIZATION_HEADER, 'Content-Type' => 'application/json']];
 		$options['body'] = json_encode(['prompt' => $prompt,'size' => Application::DEFAULT_IMAGE_SIZE,'model' => 'dall-e-2', 'n' => $n, 'response_format' => 'url', 'user' => self::TEST_USER1]);
 
 		$iResponse = $this->createMock(\OCP\Http\Client\IResponse::class);
@@ -460,7 +461,7 @@ class OpenAiControllerTest extends TestCase {
 		$options = [
 			'nextcloud' => ['allow_local_address' => true],
 			'timeout' => Application::OPENAI_DEFAULT_REQUEST_TIMEOUT,
-			'headers' => ['User-Agent' => 'Nextcloud OpenAI integration', 'Authorization' => 'Bearer This is a PHPUnit test API key', 'Content-Type' => 'application/json'],
+			'headers' => ['User-Agent' => Application::USER_AGENT, 'Authorization' => self::AUTHORIZATION_HEADER, 'Content-Type' => 'application/json'],
 		];
 		$options['body'] = json_encode(['model' => 'test_model', 'prompt' => $prompt, 'max_tokens' => $maxTokens, 'n' => $n, 'user' => self::TEST_USER1]);
 
@@ -523,7 +524,7 @@ class OpenAiControllerTest extends TestCase {
 		$options = [
 			'nextcloud' => ['allow_local_address' => true],
 			'timeout' => Application::OPENAI_DEFAULT_REQUEST_TIMEOUT,
-			'headers' => ['User-Agent' => 'Nextcloud OpenAI integration', 'Authorization' => 'Bearer This is a PHPUnit test API key', 'Content-Type' => 'application/json'],
+			'headers' => ['User-Agent' => Application::USER_AGENT, 'Authorization' => self::AUTHORIZATION_HEADER, 'Content-Type' => 'application/json'],
 		];
 		$options['body'] = json_encode(['model' => 'test_model', 'messages' => [['role' => 'user', 'content' => $prompt]], 'max_tokens' => $maxTokens, 'n' => $n, 'user' => self::TEST_USER1]);
 
@@ -588,7 +589,7 @@ class OpenAiControllerTest extends TestCase {
 		$options = [
 			'nextcloud' => ['allow_local_address' => true],
 			'timeout' => Application::OPENAI_DEFAULT_REQUEST_TIMEOUT,
-			'headers' => ['User-Agent' => 'Nextcloud OpenAI integration', 'Authorization' => 'Basic ' . base64_encode('testuser:testpassword'), 'Content-Type' => 'application/json'],
+			'headers' => ['User-Agent' => Application::USER_AGENT, 'Authorization' => 'Basic ' . base64_encode('testuser:testpassword'), 'Content-Type' => 'application/json'],
 		];
 		$options['body'] = json_encode(['model' => 'test_model', 'messages' => [['role' => 'user', 'content' => $prompt]], 'max_tokens' => $maxTokens, 'n' => $n, 'user' => self::TEST_USER1]);
 
@@ -613,7 +614,7 @@ class OpenAiControllerTest extends TestCase {
 	public function testExceedingTextQuota() {
 		$this->openAiSettingsService->setServiceUrl('');
 		$this->openAiSettingsService->setUserApiKey(self::TEST_USER1, 'This is a PHPUnit test API key');
-		
+
 		$prompt = 'This is a test prompt';
 		$n = 1;
 		$maxTokens = 42;
@@ -627,11 +628,11 @@ class OpenAiControllerTest extends TestCase {
 		$this->openAiSettingsService->setQuotas($quotas);
 
 		$this->testCreateCompletionWithOpenAi(false);
-		
+
 		// Before we disable the user specific api key, we should be able to exceed the quota
 		$result = $this->openAiApiService->isQuotaExceeded(self::TEST_USER1, Application::QUOTA_TYPE_TEXT);
 		$this->assertFalse($result);
-		
+
 		// Disable the private api key for the user:
 		$this->openAiSettingsService->setUserApiKey(self::TEST_USER1, '');
 
@@ -658,7 +659,7 @@ class OpenAiControllerTest extends TestCase {
 		$this->openAiSettingsService->setQuotas($quotas);
 
 		$this->testTranscribe(false);
-		
+
 		// Before we disable the user specific api key, we should be able to exceed the quota
 		$result = $this->openAiApiService->isQuotaExceeded(self::TEST_USER1, Application::QUOTA_TYPE_TRANSCRIPTION);
 		$this->assertFalse($result);
@@ -706,7 +707,5 @@ class OpenAiControllerTest extends TestCase {
 		$response = $this->openAiApiController->createImage('This is a test prompt', 1, Application::DEFAULT_IMAGE_SIZE);
 		$this->assertEquals(429, $response->getStatus());
 		$this->assertArrayHasKey('error', $response->getData());
-		
 	}
-
 }

--- a/tests/unit/Providers/OpenAiProviderTest.php
+++ b/tests/unit/Providers/OpenAiProviderTest.php
@@ -34,6 +34,7 @@ class OpenAiProviderTest extends TestCase {
 	public const APP_NAME = 'integration_openai';
 	public const TEST_USER1 = 'testuser';
 	public const OPENAI_API_BASE = 'https://api.openai.com/v1/';
+	public const AUTHORIZATION_HEADER = 'Bearer This is a PHPUnit test API key';
 
 	private $openAiApiService;
 	private $openAiSettingsService;
@@ -83,7 +84,7 @@ class OpenAiProviderTest extends TestCase {
 		} catch (\OCP\Db\Exception | \Exception | \Throwable $e) {
 			// Ignore
 		}
-		
+
 		// Delete quota usage for test user
 		$quotaUsageMapper = \OC::$server->get(QuotaUsageMapper::class);
 		try {
@@ -91,7 +92,7 @@ class OpenAiProviderTest extends TestCase {
 		} catch (\OCP\Db\Exception | \RuntimeException | \Exception | \Throwable $e) {
 			// Ignore
 		}
-		
+
 		$backend = new \Test\Util\User\Dummy();
 		$backend->deleteUser(self::TEST_USER1);
 		\OC::$server->get(\OCP\IUserManager::class)->removeBackend($backend);
@@ -134,7 +135,7 @@ class OpenAiProviderTest extends TestCase {
 		  }';
 
 		$url = self::OPENAI_API_BASE . 'chat/completions';
-		$options = ['timeout' => Application::OPENAI_DEFAULT_REQUEST_TIMEOUT, 'headers' => ['User-Agent' => 'Nextcloud OpenAI integration', 'Authorization' => 'Bearer This is a PHPUnit test API key', 'Content-Type' => 'application/json']];
+		$options = ['timeout' => Application::OPENAI_DEFAULT_REQUEST_TIMEOUT, 'headers' => ['User-Agent' => Application::USER_AGENT, 'Authorization' => self::AUTHORIZATION_HEADER, 'Content-Type' => 'application/json']];
 		$options['body'] = json_encode(['model' => Application::DEFAULT_COMPLETION_MODEL_ID, 'messages' => [['role' => 'user', 'content' => $prompt]], 'max_tokens' => Application::DEFAULT_MAX_NUM_OF_TOKENS, 'n' => $n, 'user' => self::TEST_USER1]);
 
 		$iResponse = $this->createMock(\OCP\Http\Client\IResponse::class);
@@ -187,10 +188,10 @@ class OpenAiProviderTest extends TestCase {
 			  "total_tokens": 21
 			}
 		}';
-		
+
 		$url = self::OPENAI_API_BASE . 'chat/completions';
 
-		$options = ['timeout' => Application::OPENAI_DEFAULT_REQUEST_TIMEOUT, 'headers' => ['User-Agent' => 'Nextcloud OpenAI integration', 'Authorization' => 'Bearer This is a PHPUnit test API key', 'Content-Type' => 'application/json']];
+		$options = ['timeout' => Application::OPENAI_DEFAULT_REQUEST_TIMEOUT, 'headers' => ['User-Agent' => Application::USER_AGENT, 'Authorization' => self::AUTHORIZATION_HEADER, 'Content-Type' => 'application/json']];
 		$options['body'] = json_encode(['model' => Application::DEFAULT_COMPLETION_MODEL_ID, 'messages' => [['role' => 'user', 'content' => 'Give me the headline of the following text:' . "\n\n" . $prompt]], 'max_tokens' => Application::DEFAULT_MAX_NUM_OF_TOKENS, 'n' => $n, 'user' => self::TEST_USER1]);
 
 		$iResponse = $this->createMock(\OCP\Http\Client\IResponse::class);
@@ -245,7 +246,7 @@ class OpenAiProviderTest extends TestCase {
 
 		$url = self::OPENAI_API_BASE . 'chat/completions';
 
-		$options = ['timeout' => Application::OPENAI_DEFAULT_REQUEST_TIMEOUT, 'headers' => ['User-Agent' => 'Nextcloud OpenAI integration', 'Authorization' => 'Bearer This is a PHPUnit test API key', 'Content-Type' => 'application/json']];
+		$options = ['timeout' => Application::OPENAI_DEFAULT_REQUEST_TIMEOUT, 'headers' => ['User-Agent' => Application::USER_AGENT, 'Authorization' => self::AUTHORIZATION_HEADER, 'Content-Type' => 'application/json']];
 		$options['body'] = json_encode(['model' => Application::DEFAULT_COMPLETION_MODEL_ID, 'messages' => [['role' => 'user', 'content' => 'Reformulate the following text:' . "\n\n" . $prompt]], 'max_tokens' => Application::DEFAULT_MAX_NUM_OF_TOKENS, 'n' => $n, 'user' => self::TEST_USER1]);
 
 		$iResponse = $this->createMock(\OCP\Http\Client\IResponse::class);
@@ -300,7 +301,7 @@ class OpenAiProviderTest extends TestCase {
 
 		$url = self::OPENAI_API_BASE . 'chat/completions';
 
-		$options = ['timeout' => Application::OPENAI_DEFAULT_REQUEST_TIMEOUT, 'headers' => ['User-Agent' => 'Nextcloud OpenAI integration', 'Authorization' => 'Bearer This is a PHPUnit test API key', 'Content-Type' => 'application/json']];
+		$options = ['timeout' => Application::OPENAI_DEFAULT_REQUEST_TIMEOUT, 'headers' => ['User-Agent' => Application::USER_AGENT, 'Authorization' => self::AUTHORIZATION_HEADER, 'Content-Type' => 'application/json']];
 		$options['body'] = json_encode(['model' => Application::DEFAULT_COMPLETION_MODEL_ID, 'messages' => [['role' => 'user', 'content' => 'Summarize the following text:' . "\n\n" . $prompt]], 'max_tokens' => Application::DEFAULT_MAX_NUM_OF_TOKENS, 'n' => $n, 'user' => self::TEST_USER1]);
 
 		$iResponse = $this->createMock(\OCP\Http\Client\IResponse::class);
@@ -359,7 +360,7 @@ class OpenAiProviderTest extends TestCase {
 
 		$url = self::OPENAI_API_BASE . 'chat/completions';
 
-		$options = ['timeout' => Application::OPENAI_DEFAULT_REQUEST_TIMEOUT, 'headers' => ['User-Agent' => 'Nextcloud OpenAI integration', 'Authorization' => 'Bearer This is a PHPUnit test API key', 'Content-Type' => 'application/json']];
+		$options = ['timeout' => Application::OPENAI_DEFAULT_REQUEST_TIMEOUT, 'headers' => ['User-Agent' => Application::USER_AGENT, 'Authorization' => self::AUTHORIZATION_HEADER, 'Content-Type' => 'application/json']];
 		$options['body'] = json_encode(['model' => Application::DEFAULT_COMPLETION_MODEL_ID, 'messages' => [['role' => 'user', 'content' => 'Translate from ' . $fromLang . ' to English (US): ' . $prompt]], 'max_tokens' => Application::DEFAULT_MAX_NUM_OF_TOKENS, 'n' => $n, 'user' => self::TEST_USER1]);
 
 		$iResponse = $this->createMock(\OCP\Http\Client\IResponse::class);


### PR DESCRIPTION
closes https://github.com/nextcloud/text2image_helper/issues/49

Auth is not an issue with OpenAI as result image URLs are accessible publicly.
But when LocalAI is set up with basic auth, we still don't use any auth when getting result images.
Tested with LocalAI behind a reverse proxy adding basic auth.