### PR TITLE
Allow admins to set extra params for completion requests

### DIFF
--- a/lib/Service/OpenAiAPIService.php
+++ b/lib/Service/OpenAiAPIService.php
@@ -254,6 +254,12 @@ class OpenAiAPIService {
 		if ($userId !== null) {
 			$params['user'] = $userId;
 		}
+
+		$modelExtraParams = $this->getExtraParams('llm_extra_params');
+		if ($modelExtraParams !== null) {
+			$params = array_merge($modelExtraParams, $params);
+		}
+
 		$response = $this->request($userId, 'completions', $params, 'POST');
 
 		if (!isset($response['choices'])) {
@@ -315,6 +321,11 @@ class OpenAiAPIService {
 			$params['user'] = $userId;
 		}
 
+		$modelExtraParams = $this->getExtraParams('llm_extra_params');
+		if ($modelExtraParams !== null) {
+			$params = array_merge($modelExtraParams, $params);
+		}
+
 		$response = $this->request($userId, 'chat/completions', $params, 'POST');
 
 		if (!isset($response['choices'])) {
@@ -338,6 +349,22 @@ class OpenAiAPIService {
 		}
 
 		return $completions;
+	}
+
+	/**
+	 * @param string $configKey
+	 * @return array|null
+	 */
+	private function getExtraParams(string $configKey): ?array {
+		$stringValue = $this->config->getAppValue(Application::APP_ID, $configKey);
+		if ($stringValue === '') {
+			return null;
+		}
+		$arrayValue = json_decode($stringValue, true);
+		if ($arrayValue === null) {
+			return null;
+		}
+		return $arrayValue;
 	}
 
 	/**

--- a/lib/Service/OpenAiSettingsService.php
+++ b/lib/Service/OpenAiSettingsService.php
@@ -353,6 +353,10 @@ class OpenAiSettingsService {
 	}
 
 	public function setLlmExtraParams(string $llmExtraParams): void {
+		$paramsArray = json_decode($llmExtraParams, true);
+		if ($paramsArray === null) {
+			throw new Exception('Invalid model extra parameters');
+		}
 		$this->config->setAppValue(Application::APP_ID, 'llm_extra_params', $llmExtraParams);
 	}
 

--- a/lib/Service/OpenAiSettingsService.php
+++ b/lib/Service/OpenAiSettingsService.php
@@ -34,6 +34,7 @@ class OpenAiSettingsService {
 		'api_key' => 'string',
 		'default_completion_model_id' => 'string',
 		'max_tokens' => 'integer',
+		'llm_extra_params' => 'string',
 		'quota_period' => 'integer',
 		'quotas' => 'array',
 		'translation_provider_enabled' => 'boolean',
@@ -104,6 +105,13 @@ class OpenAiSettingsService {
 	 */
 	public function getMaxTokens(): int {
 		return intval($this->config->getAppValue(Application::APP_ID, 'max_tokens', strval(Application::DEFAULT_MAX_NUM_OF_TOKENS))) ?: Application::DEFAULT_MAX_NUM_OF_TOKENS;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getLlmExtraParams(): string {
+		return $this->config->getAppValue(Application::APP_ID, 'llm_extra_params');
 	}
 
 	/**
@@ -194,6 +202,7 @@ class OpenAiSettingsService {
 			'api_key' => $this->getAdminApiKey(),
 			'default_completion_model_id' => $this->getAdminDefaultCompletionModelId(),
 			'max_tokens' => $this->getMaxTokens(),
+			'llm_extra_params' => $this->getLlmExtraParams(),
 			// Updated to get max tokens
 			'quota_period' => $this->getQuotaPeriod(),
 			// Updated to get quota period
@@ -343,6 +352,10 @@ class OpenAiSettingsService {
 		$this->config->setAppValue(Application::APP_ID, 'max_tokens', strval($maxTokens));
 	}
 
+	public function setLlmExtraParams(string $llmExtraParams): void {
+		$this->config->setAppValue(Application::APP_ID, 'llm_extra_params', $llmExtraParams);
+	}
+
 	/**
 	 * Setter for quotaPeriod; minimum is 1 day
 	 * @param int $quotaPeriod
@@ -428,6 +441,9 @@ class OpenAiSettingsService {
 		}
 		if (isset($adminConfig['max_tokens'])) {
 			$this->setMaxTokens($adminConfig['max_tokens']);
+		}
+		if (isset($adminConfig['llm_extra_params'])) {
+			$this->setLlmExtraParams($adminConfig['llm_extra_params']);
 		}
 		if (isset($adminConfig['quota_period'])) {
 			$this->setQuotaPeriod($adminConfig['quota_period']);

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -85,6 +85,25 @@
 					</a>
 				</div>
 				<div class="line">
+					<label for="llm-extra-params">
+						{{ t('integration_openai', 'Extra completion model parameters') }}
+					</label>
+					<NcTextField
+						id="llm-extra-params"
+						class="input"
+						:value.sync="state.llm_extra_params"
+						:label-outside="true"
+						:show-trailing-button="!!state.llm_extra_params"
+						@update:value="onInput(false)"
+						@trailing-button-click="state.llm_extra_params = '' ; onInput(false)" />
+					<NcButton type="tertiary"
+						:title="llmExtraParamHint">
+						<template #icon>
+							<HelpCircleIcon />
+						</template>
+					</NcButton>
+				</div>
+				<div class="line">
 					<label for="openai-api-timeout">
 						<TimerAlertOutlineIcon :size="20" class="icon" />
 						{{ t('integration_openai', 'Request timeout (seconds)') }}
@@ -274,6 +293,7 @@ import OpenAiIcon from './icons/OpenAiIcon.vue'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcSelect from '@nextcloud/vue/dist/Components/NcSelect.js'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadioSwitch.js'
+import NcTextField from '@nextcloud/vue/dist/Components/NcTextField.js'
 
 import { loadState } from '@nextcloud/initial-state'
 import { generateUrl } from '@nextcloud/router'
@@ -294,6 +314,7 @@ export default {
 		NcButton,
 		NcSelect,
 		NcCheckboxRadioSwitch,
+		NcTextField,
 	},
 
 	props: [],
@@ -307,6 +328,7 @@ export default {
 			selectedModel: null,
 			apiKeyUrl: 'https://platform.openai.com/account/api-keys',
 			quotaInfo: null,
+			llmExtraParamHint: t('integration_openai', 'Check the API documentation to get the list of all available parameters. For example: {example}', { example: '{"stop":".","temperature":0.7}' }, null, { escape: false, sanitize: false }),
 		}
 	},
 
@@ -402,6 +424,7 @@ export default {
 					chat_endpoint_enabled: this.state.chat_endpoint_enabled,
 					request_timeout: this.state.request_timeout,
 					max_tokens: this.state.max_tokens,
+					llm_extra_params: this.state.llm_extra_params,
 					quota_period: this.state.quota_period,
 					quotas: this.state.quotas,
 				}).then(() => {
@@ -470,7 +493,7 @@ export default {
 			display: flex;
 			align-items: center;
 		}
-		> input {
+		> input, .input {
 			width: 300px;
 		}
 		> input:invalid {

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -86,7 +86,7 @@
 				</div>
 				<div class="line">
 					<label for="llm-extra-params">
-						{{ t('integration_openai', 'Extra completion model parameters') }}
+						{{ t('integration_openai', 'Extra completion model parameters (as a JSON object)') }}
 					</label>
 					<NcTextField
 						id="llm-extra-params"
@@ -489,12 +489,13 @@ export default {
 
 	.line {
 		> label {
-			width: 300px;
+			width: 350px;
 			display: flex;
 			align-items: center;
 		}
 		> input, .input {
-			width: 300px;
+			width: 350px;
+			margin-top: 0;
 		}
 		> input:invalid {
 			border-color: var(--color-error);


### PR DESCRIPTION
Before we get dynamic parameters in AI providers, it's still nice to be able to manually set extra parameters for the completion request.