### PR TITLE
Refresh admin settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@ as they are now included in the [Assistant app](https://apps.nextcloud.com/apps/
 
 This app implements:
 
-* Text generation providers: Free prompt, Summarize, Headline and Reformulate (using any available language model)
+* Text generation providers: Free prompt, Summarize, Headline and Reformulate (using any available large language model)
 * A Translation provider (using any available language model)
 * A SpeechToText provider (using Whisper)
+* An image generation provider
 
-Instead of connecting to the OpenAI API for these, you can also connect to a self-hosted [LocalAI](https://localai.io) instance.
+Instead of connecting to the OpenAI API for these, you can also connect to a self-hosted [LocalAI](https://localai.io) instance
+or to any service that implements an API similar to the OpenAI one, for example: [Plusserver](https://www.plusserver.com/en/ai-platform/).
 
 ## Ethical AI Rating
 ### Rating for Text generation using ChatGPT via OpenAI API: 🔴
@@ -78,10 +80,12 @@ Learn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud
 
 ### Admin settings
 
-There is a "Connected accounts" **admin** settings section to set a global OpenAI API key or LocalAI credentials for the Nextcloud instance.
-It is also possible to configure default models and quota settings.
+There is a "Connected accounts" **admin** settings section where you can:
+* Choose whether you use OpenAI, a LocalAI instance or another remote service
+* Set a global API key (or basic auth credentials) for the Nextcloud instance
+* Configure default models and quota settings
 
 ### Personal settings
 
-There is a "Connected accounts" **personal** settings section to let users set their personal OpenAI API key or LocalAI credentials.
+There is a "Connected accounts" **personal** settings section to let users set their personal API key or basic auth credentials.
 Users can also see their quota information there.

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -9,11 +9,13 @@ as they are now included in the [Assistant app](https://apps.nextcloud.com/apps/
 
 This app implements:
 
-* Text generation providers: Free prompt, Summarize, Headline and Reformulate (using any available language model)
+* Text generation providers: Free prompt, Summarize, Headline and Reformulate (using any available large language model)
 * A Translation provider (using any available language model)
 * A SpeechToText provider (using Whisper)
+* An image generation provider
 
-Instead of connecting to the OpenAI API for these, you can also connect to a self-hosted [LocalAI](https://localai.io) instance.
+Instead of connecting to the OpenAI API for these, you can also connect to a self-hosted [LocalAI](https://localai.io) instance
+or to any service that implements an API similar to the OpenAI one, for example: [Plusserver](https://www.plusserver.com/en/ai-platform/).
 
 ## Ethical AI Rating
 ### Rating for Text generation using ChatGPT via OpenAI API: 🔴

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -76,11 +76,15 @@ class Application extends App implements IBootstrap {
 			$context->registerSpeechToTextProvider(STTProvider::class);
 		}
 
-		$context->registerTextProcessingProvider(FreePromptProvider::class);
-		$context->registerTextProcessingProvider(SummaryProvider::class);
-		$context->registerTextProcessingProvider(HeadlineProvider::class);
-		$context->registerTextProcessingProvider(ReformulateProvider::class);
-		$context->registerTextToImageProvider(TextToImageProvider::class);
+		if ($this->config->getAppValue(Application::APP_ID, 'llm_provider_enabled', '1') === '1') {
+			$context->registerTextProcessingProvider(FreePromptProvider::class);
+			$context->registerTextProcessingProvider(SummaryProvider::class);
+			$context->registerTextProcessingProvider(HeadlineProvider::class);
+			$context->registerTextProcessingProvider(ReformulateProvider::class);
+		}
+		if ($this->config->getAppValue(Application::APP_ID, 't2i_provider_enabled', '1') === '1') {
+			$context->registerTextToImageProvider(TextToImageProvider::class);
+		}
 
 		$context->registerCapability(Capabilities::class);
 	}

--- a/lib/Service/OpenAiAPIService.php
+++ b/lib/Service/OpenAiAPIService.php
@@ -58,6 +58,21 @@ class OpenAiAPIService {
 	}
 
 	/**
+	 * @return string
+	 */
+	public function getServiceName(): string {
+		if ($this->isUsingOpenAi()) {
+			return 'OpenAI';
+		} else {
+			$serviceName = $this->openAiSettingsService->getServiceName();
+			if ($serviceName === '') {
+				return 'LocalAI';
+			}
+			return $serviceName;
+		}
+	}
+
+	/**
 	 * @param string $userId
 	 * @return array|string[]
 	 * @throws Exception

--- a/lib/Service/OpenAiSettingsService.php
+++ b/lib/Service/OpenAiSettingsService.php
@@ -31,6 +31,7 @@ class OpenAiSettingsService {
 	private const ADMIN_CONFIG_TYPES = [
 		'request_timeout' => 'integer',
 		'url' => 'string',
+		'service_name' => 'string',
 		'api_key' => 'string',
 		'default_completion_model_id' => 'string',
 		'max_tokens' => 'integer',
@@ -90,7 +91,14 @@ class OpenAiSettingsService {
 	 * @return string
 	 */
 	public function getServiceUrl(): string {
-		return $this->config->getAppValue(Application::APP_ID, 'url', '');
+		return $this->config->getAppValue(Application::APP_ID, 'url');
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getServiceName(): string {
+		return $this->config->getAppValue(Application::APP_ID, 'service_name');
 	}
 
 	/**
@@ -199,6 +207,7 @@ class OpenAiSettingsService {
 		return [
 			'request_timeout' => $this->getRequestTimeout(),
 			'url' => $this->getServiceUrl(),
+			'service_name' => $this->getServiceName(),
 			'api_key' => $this->getAdminApiKey(),
 			'default_completion_model_id' => $this->getAdminDefaultCompletionModelId(),
 			'max_tokens' => $this->getMaxTokens(),
@@ -331,6 +340,16 @@ class OpenAiSettingsService {
 		}
 		$this->config->setAppValue(Application::APP_ID, 'url', $serviceUrl);
 	}
+
+	/**
+	 * @param string $serviceName
+	 * @return void
+	 * @throws Exception
+	 */
+	public function setServiceName(string $serviceName): void {
+		$this->config->setAppValue(Application::APP_ID, 'service_name', $serviceName);
+	}
+
 	/**
 	 * @param int $requestTimeout
 	 * @return void
@@ -436,6 +455,9 @@ class OpenAiSettingsService {
 				$adminConfig['url'] = substr($adminConfig['url'], 0, -1) ?: $adminConfig['url'];
 			}
 			$this->setServiceUrl($adminConfig['url']);
+		}
+		if (isset($adminConfig['service_name'])) {
+			$this->setServiceName($adminConfig['service_name']);
 		}
 		if (isset($adminConfig['api_key'])) {
 			$this->setAdminApiKey($adminConfig['api_key']);

--- a/lib/Service/OpenAiSettingsService.php
+++ b/lib/Service/OpenAiSettingsService.php
@@ -39,6 +39,8 @@ class OpenAiSettingsService {
 		'quota_period' => 'integer',
 		'quotas' => 'array',
 		'translation_provider_enabled' => 'boolean',
+		'llm_provider_enabled' => 'boolean',
+		't2i_provider_enabled' => 'boolean',
 		'stt_provider_enabled' => 'boolean',
 		'chat_endpoint_enabled' => 'boolean',
 		'basic_user' => 'string',
@@ -218,6 +220,8 @@ class OpenAiSettingsService {
 			'quotas' => $this->getQuotas(),
 			// Get quotas from the config value and return it
 			'translation_provider_enabled' => $this->getTranslationProviderEnabled(),
+			'llm_provider_enabled' => $this->getLlmProviderEnabled(),
+			't2i_provider_enabled' => $this->getT2iProviderEnabled(),
 			'stt_provider_enabled' => $this->getSttProviderEnabled(),
 			'chat_endpoint_enabled' => $this->getChatEndpointEnabled(),
 			'basic_user' => $this->getAdminBasicUser(),
@@ -248,6 +252,21 @@ class OpenAiSettingsService {
 	public function getTranslationProviderEnabled(): bool {
 		return $this->config->getAppValue(Application::APP_ID, 'translation_provider_enabled', '1') === '1';
 	}
+
+	/**
+	 * @return bool
+	 */
+	public function getLlmProviderEnabled(): bool {
+		return $this->config->getAppValue(Application::APP_ID, 'llm_provider_enabled', '1') === '1';
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function getT2iProviderEnabled(): bool {
+		return $this->config->getAppValue(Application::APP_ID, 't2i_provider_enabled', '1') === '1';
+	}
+
 	/**
 	 * @return bool
 	 */
@@ -480,6 +499,12 @@ class OpenAiSettingsService {
 		if (isset($adminConfig['translation_provider_enabled'])) {
 			$this->setTranslationProviderEnabled($adminConfig['translation_provider_enabled']);
 		}
+		if (isset($adminConfig['llm_provider_enabled'])) {
+			$this->setLlmProviderEnabled($adminConfig['llm_provider_enabled']);
+		}
+		if (isset($adminConfig['t2i_provider_enabled'])) {
+			$this->setT2iProviderEnabled($adminConfig['t2i_provider_enabled']);
+		}
 		if (isset($adminConfig['stt_provider_enabled'])) {
 			$this->setSttProviderEnabled($adminConfig['stt_provider_enabled']);
 		}
@@ -532,6 +557,23 @@ class OpenAiSettingsService {
 	public function setTranslationProviderEnabled(bool $enabled): void {
 		$this->config->setAppValue(Application::APP_ID, 'translation_provider_enabled', $enabled ? '1' : '0');
 	}
+
+	/**
+	 * @param bool $enabled
+	 * @return void
+	 */
+	public function setLlmProviderEnabled(bool $enabled): void {
+		$this->config->setAppValue(Application::APP_ID, 'llm_provider_enabled', $enabled ? '1' : '0');
+	}
+
+	/**
+	 * @param bool $enabled
+	 * @return void
+	 */
+	public function setT2iProviderEnabled(bool $enabled): void {
+		$this->config->setAppValue(Application::APP_ID, 't2i_provider_enabled', $enabled ? '1' : '0');
+	}
+
 	/**
 	 * @param bool $enabled
 	 * @return void

--- a/lib/TextProcessing/FreePromptProvider.php
+++ b/lib/TextProcessing/FreePromptProvider.php
@@ -9,7 +9,6 @@ use OCA\OpenAi\AppInfo\Application;
 use OCA\OpenAi\Service\OpenAiAPIService;
 use OCA\OpenAi\Service\OpenAiSettingsService;
 use OCP\IConfig;
-use OCP\IL10N;
 use OCP\TextProcessing\FreePromptTaskType;
 use OCP\TextProcessing\IProviderWithExpectedRuntime;
 use OCP\TextProcessing\IProviderWithUserId;
@@ -24,16 +23,13 @@ class FreePromptProvider implements IProviderWithExpectedRuntime, IProviderWithU
 	public function __construct(
 		private OpenAiAPIService $openAiAPIService,
 		private IConfig $config,
-		private IL10N $l10n,
 		private ?string $userId,
 		private OpenAiSettingsService $openAiSettingsService,
 	) {
 	}
 
 	public function getName(): string {
-		return $this->openAiAPIService->isUsingOpenAi()
-			? $this->l10n->t('OpenAI integration')
-			: $this->l10n->t('LocalAI integration');
+		return $this->openAiAPIService->getServiceName();
 	}
 
 	public function process(string $prompt): string {

--- a/lib/TextProcessing/HeadlineProvider.php
+++ b/lib/TextProcessing/HeadlineProvider.php
@@ -9,7 +9,6 @@ use OCA\OpenAi\AppInfo\Application;
 use OCA\OpenAi\Service\OpenAiAPIService;
 use OCA\OpenAi\Service\OpenAiSettingsService;
 use OCP\IConfig;
-use OCP\IL10N;
 use OCP\TextProcessing\HeadlineTaskType;
 use OCP\TextProcessing\IProviderWithExpectedRuntime;
 use OCP\TextProcessing\IProviderWithUserId;
@@ -23,16 +22,13 @@ class HeadlineProvider implements IProviderWithExpectedRuntime, IProviderWithUse
 	public function __construct(
 		private OpenAiAPIService $openAiAPIService,
 		private IConfig $config,
-		private IL10N $l10n,
 		private ?string $userId,
 		private OpenAiSettingsService $openAiSettingsService,
 	) {
 	}
 
 	public function getName(): string {
-		return $this->openAiAPIService->isUsingOpenAi()
-			? $this->l10n->t('OpenAI integration')
-			: $this->l10n->t('LocalAI integration');
+		return $this->openAiAPIService->getServiceName();
 	}
 
 	public function process(string $prompt): string {

--- a/lib/TextProcessing/ReformulateProvider.php
+++ b/lib/TextProcessing/ReformulateProvider.php
@@ -9,7 +9,6 @@ use OCA\OpenAi\AppInfo\Application;
 use OCA\OpenAi\Service\OpenAiAPIService;
 use OCA\OpenAi\Service\OpenAiSettingsService;
 use OCP\IConfig;
-use OCP\IL10N;
 use OCP\TextProcessing\IProviderWithExpectedRuntime;
 use OCP\TextProcessing\IProviderWithUserId;
 use RuntimeException;
@@ -22,16 +21,13 @@ class ReformulateProvider implements IProviderWithExpectedRuntime, IProviderWith
 	public function __construct(
 		private OpenAiAPIService $openAiAPIService,
 		private IConfig $config,
-		private IL10N $l10n,
 		private ?string $userId,
 		private OpenAiSettingsService $openAiSettingsService,
 	) {
 	}
 
 	public function getName(): string {
-		return $this->openAiAPIService->isUsingOpenAi()
-			? $this->l10n->t('OpenAI integration')
-			: $this->l10n->t('LocalAI integration');
+		return $this->openAiAPIService->getServiceName();
 	}
 
 	public function process(string $prompt): string {

--- a/lib/TextProcessing/SummaryProvider.php
+++ b/lib/TextProcessing/SummaryProvider.php
@@ -9,7 +9,6 @@ use OCA\OpenAi\AppInfo\Application;
 use OCA\OpenAi\Service\OpenAiAPIService;
 use OCA\OpenAi\Service\OpenAiSettingsService;
 use OCP\IConfig;
-use OCP\IL10N;
 use OCP\TextProcessing\IProviderWithExpectedRuntime;
 use OCP\TextProcessing\IProviderWithUserId;
 use OCP\TextProcessing\SummaryTaskType;
@@ -23,16 +22,13 @@ class SummaryProvider implements IProviderWithExpectedRuntime, IProviderWithUser
 	public function __construct(
 		private OpenAiAPIService $openAiAPIService,
 		private IConfig $config,
-		private IL10N $l10n,
 		private ?string $userId,
 		private OpenAiSettingsService $openAiSettingsService,
 	) {
 	}
 
 	public function getName(): string {
-		return $this->openAiAPIService->isUsingOpenAi()
-			? $this->l10n->t('OpenAI integration')
-			: $this->l10n->t('LocalAI integration');
+		return $this->openAiAPIService->getServiceName();
 	}
 
 	public function process(string $prompt): string {

--- a/lib/TextToImage/TextToImageProvider.php
+++ b/lib/TextToImage/TextToImageProvider.php
@@ -33,7 +33,7 @@ class TextToImageProvider implements IProvider {
 	public function getName(): string {
 		return $this->openAiAPIService->isUsingOpenAi()
 			? $this->l->t('OpenAI\'s DALL-E 2 Text-To-Image')
-			: $this->l->t('LocalAI\'s stable diffusion Text-To-Image');
+			: $this->openAiAPIService->getServiceName();
 	}
 
 	/**

--- a/lib/Translation/TranslationProvider.php
+++ b/lib/Translation/TranslationProvider.php
@@ -51,7 +51,7 @@ class TranslationProvider implements ITranslationProvider, IDetectLanguageProvid
 	}
 
 	public function getName(): string {
-		return $this->openAiAPIService->isUsingOpenAi() ? 'OpenAI' : 'LocalAI';
+		return $this->openAiAPIService->getServiceName();
 	}
 
 	public function getAvailableLanguages(): array {

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -48,6 +48,91 @@
 						</template>
 					</NcButton>
 				</div>
+			</div>
+			<div>
+				<h2 class="mid-setting-heading">
+					{{ t('integration_openai', 'Authentication') }}
+				</h2>
+				<div v-show="state.url !== ''" class="line">
+					<label>
+						{{ t('integration_openai', 'Authentication method') }}
+					</label>
+					<div class="radios">
+						<NcCheckboxRadioSwitch
+							:button-variant="true"
+							:checked.sync="state.use_basic_auth"
+							type="radio"
+							:value="false"
+							button-variant-grouped="horizontal"
+							name="auth_method"
+							@update:checked="onCheckboxChanged($event, 'use_basic_auth')">
+							{{ t('assistant', 'API key') }}
+						</NcCheckboxRadioSwitch>
+						<NcCheckboxRadioSwitch
+							:button-variant="true"
+							:checked.sync="state.use_basic_auth"
+							type="radio"
+							:value="true"
+							button-variant-grouped="horizontal"
+							name="auth_method"
+							@update:checked="onCheckboxChanged($event, 'use_basic_auth')">
+							{{ t('assistant', 'Basic Authentication') }}
+						</NcCheckboxRadioSwitch>
+					</div>
+				</div>
+				<div v-show="state.url === '' || !state.use_basic_auth" class="line">
+					<NcTextField
+						id="openai-api-key"
+						class="input"
+						:value.sync="state.api_key"
+						type="password"
+						:label="t('integration_openai', 'API key (mandatory with OpenAI)')"
+						:show-trailing-button="!!state.api_key"
+						@update:value="onInput"
+						@trailing-button-click="state.api_key = '' ; onInput">
+						<KeyIcon />
+					</NcTextField>
+				</div>
+				<p v-show="state.url === ''" class="settings-hint">
+					<InformationOutlineIcon :size="20" class="icon" />
+					{{ t('integration_openai', 'You can create an API key in your OpenAI account settings:') }}
+					&nbsp;
+					<a :href="apiKeyUrl" target="_blank" class="external">
+						{{ apiKeyUrl }}
+					</a>
+				</p>
+				<div v-show="state.url !== '' && state.use_basic_auth">
+					<div class="line">
+						<NcTextField
+							id="openai-basic-user"
+							class="input"
+							:value.sync="state.basic_user"
+							:label="t('integration_openai', 'Basic Auth user')"
+							:show-trailing-button="!!state.basic_user"
+							@update:value="onInput"
+							@trailing-button-click="state.basic_user = '' ; onInput">
+							<AccountIcon />
+						</NcTextField>
+					</div>
+					<div class="line">
+						<NcTextField
+							id="openai-basic-password"
+							class="input"
+							:value.sync="state.basic_password"
+							type="password"
+							:label="t('integration_openai', 'Basic Auth password')"
+							:show-trailing-button="!!state.basic_password"
+							@update:value="onInput"
+							@trailing-button-click="state.basic_password = '' ; onInput">
+							<KeyIcon />
+						</NcTextField>
+					</div>
+				</div>
+			</div>
+			<div>
+				<h2 class="mid-setting-heading">
+					{{ t('integration_openai', 'Text generation') }}
+				</h2>
 				<div v-show="state.url !== ''" class="line">
 					<label>
 						<EarthIcon :size="20" class="icon" />
@@ -140,86 +225,6 @@
 						@trailing-button-click="state.request_timeout = '' ; onInput(false)">
 						<TimerAlertOutlineIcon />
 					</NcTextField>
-				</div>
-			</div>
-			<div>
-				<h2 class="mid-setting-heading">
-					{{ t('integration_openai', 'Authentication') }}
-				</h2>
-				<div v-show="state.url !== ''" class="line">
-					<label>
-						{{ t('integration_openai', 'Authentication method') }}
-					</label>
-					<div class="radios">
-						<NcCheckboxRadioSwitch
-							:button-variant="true"
-							:checked.sync="state.use_basic_auth"
-							type="radio"
-							:value="false"
-							button-variant-grouped="horizontal"
-							name="auth_method"
-							@update:checked="onCheckboxChanged($event, 'use_basic_auth')">
-							{{ t('assistant', 'API key') }}
-						</NcCheckboxRadioSwitch>
-						<NcCheckboxRadioSwitch
-							:button-variant="true"
-							:checked.sync="state.use_basic_auth"
-							type="radio"
-							:value="true"
-							button-variant-grouped="horizontal"
-							name="auth_method"
-							@update:checked="onCheckboxChanged($event, 'use_basic_auth')">
-							{{ t('assistant', 'Basic Authentication') }}
-						</NcCheckboxRadioSwitch>
-					</div>
-				</div>
-				<div v-show="state.url === '' || !state.use_basic_auth" class="line">
-					<NcTextField
-						id="openai-api-key"
-						class="input"
-						:value.sync="state.api_key"
-						type="password"
-						:label="t('integration_openai', 'API key (mandatory with OpenAI)')"
-						:show-trailing-button="!!state.api_key"
-						@update:value="onInput"
-						@trailing-button-click="state.api_key = '' ; onInput">
-						<KeyIcon />
-					</NcTextField>
-				</div>
-				<p v-show="state.url === ''" class="settings-hint">
-					<InformationOutlineIcon :size="20" class="icon" />
-					{{ t('integration_openai', 'You can create an API key in your OpenAI account settings:') }}
-					&nbsp;
-					<a :href="apiKeyUrl" target="_blank" class="external">
-						{{ apiKeyUrl }}
-					</a>
-				</p>
-				<div v-show="state.url !== '' && state.use_basic_auth">
-					<div class="line">
-						<NcTextField
-							id="openai-basic-user"
-							class="input"
-							:value.sync="state.basic_user"
-							:label="t('integration_openai', 'Basic Auth user')"
-							:show-trailing-button="!!state.basic_user"
-							@update:value="onInput"
-							@trailing-button-click="state.basic_user = '' ; onInput">
-							<AccountIcon />
-						</NcTextField>
-					</div>
-					<div class="line">
-						<NcTextField
-							id="openai-basic-password"
-							class="input"
-							:value.sync="state.basic_password"
-							type="password"
-							:label="t('integration_openai', 'Basic Auth password')"
-							:show-trailing-button="!!state.basic_password"
-							@update:value="onInput"
-							@trailing-button-click="state.basic_password = '' ; onInput">
-							<KeyIcon />
-						</NcTextField>
-					</div>
 				</div>
 			</div>
 			<div>

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -308,6 +308,16 @@
 					{{ t('integration_openai', 'Translation provider (to translate Talk messages for example)') }}
 				</NcCheckboxRadioSwitch>
 				<NcCheckboxRadioSwitch
+					:checked="state.llm_provider_enabled"
+					@update:checked="onCheckboxChanged($event, 'llm_provider_enabled', false)">
+					{{ t('integration_openai', 'Text processing provider (to generate text, summarize etc...)') }}
+				</NcCheckboxRadioSwitch>
+				<NcCheckboxRadioSwitch
+					:checked="state.t2i_provider_enabled"
+					@update:checked="onCheckboxChanged($event, 't2i_provider_enabled', false)">
+					{{ t('integration_openai', 'Image generation provider') }}
+				</NcCheckboxRadioSwitch>
+				<NcCheckboxRadioSwitch
 					:checked="state.stt_provider_enabled"
 					@update:checked="onCheckboxChanged($event, 'stt_provider_enabled', false)">
 					{{ t('integration_openai', 'Speech-to-text provider (to transcribe Talk recordings for example)') }}

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -27,10 +27,27 @@
 				</div>
 				<p class="settings-hint">
 					<InformationOutlineIcon :size="20" class="icon" />
-					{{ t('integration_openai', 'This should be the address of your LocalAI instance (or any service implementing a similar API than OpenAI) from the point of view of your Nextcloud server.') }}
+					{{ t('integration_openai', 'This should be the address of your LocalAI instance (or any service implementing an API similar to OpenAI). This URL will be accessed by your Nextcloud server.') }}
 					<br>
 					{{ t('integration_openai', 'This can be a local address with a port like {example}. In this case make sure \'allow_local_remote_servers\' is set to true in config.php', { example : 'http://localhost:8080' }) }}
 				</p>
+				<div v-if="state.url !== ''" class="line">
+					<NcTextField
+						id="openai-service-name"
+						class="input"
+						:value.sync="state.service_name"
+						:label="t('integration_openai', 'Service name (optional)')"
+						:placeholder="t('integration_openai', 'Example: LocalAI of university ABC')"
+						:show-trailing-button="!!state.service_name"
+						@update:value="onInput(false)"
+						@trailing-button-click="state.service_name = '' ; onInput(false)" />
+					<NcButton type="tertiary"
+						:title="t('integration_openai', 'This name will be displayed as provider name in the AI admin settings')">
+						<template #icon>
+							<HelpCircleIcon />
+						</template>
+					</NcButton>
+				</div>
 				<div v-show="state.url !== ''" class="line">
 					<label>
 						<EarthIcon :size="20" class="icon" />
@@ -452,6 +469,7 @@ export default {
 					basic_user: this.state.basic_user,
 					basic_password: this.state.basic_password,
 					url: this.state.url,
+					service_name: this.state.service_name,
 					chat_endpoint_enabled: this.state.chat_endpoint_enabled,
 					request_timeout: this.state.request_timeout,
 					max_tokens: this.state.max_tokens,

--- a/tests/unit/Providers/OpenAiProviderTest.php
+++ b/tests/unit/Providers/OpenAiProviderTest.php
@@ -96,7 +96,6 @@ class OpenAiProviderTest extends TestCase {
 		$freePromptProvider = new FreePromptProvider(
 			$this->openAiApiService,
 			\OC::$server->get(IConfig::class),
-			$this->createMock(\OCP\IL10N::class),
 			self::TEST_USER1,
 			$this->openAiSettingsService);
 
@@ -151,7 +150,6 @@ class OpenAiProviderTest extends TestCase {
 		$headlineProvider = new HeadlineProvider(
 			$this->openAiApiService,
 			\OC::$server->get(IConfig::class),
-			$this->createMock(\OCP\IL10N::class),
 			self::TEST_USER1,
 			$this->openAiSettingsService);
 
@@ -206,7 +204,6 @@ class OpenAiProviderTest extends TestCase {
 		$reformulateProvider = new ReformulateProvider(
 			$this->openAiApiService,
 			\OC::$server->get(IConfig::class),
-			$this->createMock(\OCP\IL10N::class),
 			self::TEST_USER1,
 			$this->openAiSettingsService);
 
@@ -261,7 +258,6 @@ class OpenAiProviderTest extends TestCase {
 		$summaryProvider = new SummaryProvider(
 			$this->openAiApiService,
 			\OC::$server->get(IConfig::class),
-			$this->createMock(\OCP\IL10N::class),
 			self::TEST_USER1,
 			$this->openAiSettingsService);
 


### PR DESCRIPTION
* use nextcloud/vue components instead of pure html inputs
* adjust labels so it's clear that the service URL can point to any service with an OpenAI-like API
* adjust README and info.xml to make it more explicit which services this app is compatible with, mention Plusserver
* add "service name" admin setting which is then used by all the providers so the AI provider selection (in AI admin settings) is clearer
* allow admins to toggle each provider
* reorganize admin settings subsections, group text processing stuff in a new subsection

| before | after |
|---|---|
|  ![image](https://github.com/nextcloud/integration_openai/assets/11291457/a5313bcc-a6b5-4caf-93f1-76473eb5cc78) | ![image](https://github.com/nextcloud/integration_openai/assets/11291457/8445c1c5-756e-4141-a3ef-f876e09b86ca) |
| ![image](https://github.com/nextcloud/integration_openai/assets/11291457/99ad735c-c765-4f3e-a253-04a2187e6560) | ![image](https://github.com/nextcloud/integration_openai/assets/11291457/eca867fc-f5c1-4005-a732-4d7873bd3033) |

