### PR TITLE
Fix and clarify default models

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -42,6 +42,7 @@ class Application extends App implements IBootstrap {
 
 	public const DEFAULT_MODEL_ID = 'Default';
 	public const DEFAULT_COMPLETION_MODEL_ID = 'gpt-3.5-turbo';
+	public const DEFAULT_IMAGE_MODEL_ID = 'dall-e-2';
 	public const DEFAULT_TRANSCRIPTION_MODEL_ID = 'whisper-1';
 	public const DEFAULT_IMAGE_SIZE = '1024x1024';
 	public const MAX_GENERATION_IDLE_TIME = 60 * 60 * 24 * 10;

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -41,7 +41,7 @@ class ConfigController extends Controller {
 	 */
 	#[NoAdminRequired]
 	public function setUserConfig(array $values): DataResponse {
-		if (isset($values['api_key']) || isset($values['basic_password'])) {
+		if (isset($values['api_key']) || isset($values['basic_password']) || isset($values['basic_user'])) {
 			return new DataResponse('', Http::STATUS_BAD_REQUEST);
 		}
 		try {
@@ -77,7 +77,7 @@ class ConfigController extends Controller {
 	 * @return DataResponse
 	 */
 	public function setAdminConfig(array $values): DataResponse {
-		if (isset($values['api_key']) || isset($values['basic_password'])) {
+		if (isset($values['api_key']) || isset($values['basic_password']) || isset($values['basic_user']) || isset($values['url'])) {
 			return new DataResponse('', Http::STATUS_BAD_REQUEST);
 		}
 		try {

--- a/lib/OldProcessing/TextToImage/TextToImageProvider.php
+++ b/lib/OldProcessing/TextToImage/TextToImageProvider.php
@@ -9,6 +9,7 @@ namespace OCA\OpenAi\OldProcessing\TextToImage;
 use OCA\OpenAi\AppInfo\Application;
 use OCA\OpenAi\Service\OpenAiAPIService;
 use OCP\Http\Client\IClientService;
+use OCP\IConfig;
 use OCP\IL10N;
 use OCP\TextToImage\IProvider;
 use Psr\Log\LoggerInterface;
@@ -19,6 +20,7 @@ class TextToImageProvider implements IProvider {
 		private LoggerInterface $logger,
 		private IL10N $l,
 		private IClientService $clientService,
+		private IConfig $config,
 		private ?string $userId,
 	) {
 	}
@@ -42,7 +44,8 @@ class TextToImageProvider implements IProvider {
 	public function generate(string $prompt, array $resources): void {
 		$startTime = time();
 		try {
-			$apiResponse = $this->openAiAPIService->requestImageCreation($this->userId, $prompt, count($resources));
+			$model = $this->config->getAppValue(Application::APP_ID, 'default_image_model_id') ?: Application::DEFAULT_MODEL_ID;
+			$apiResponse = $this->openAiAPIService->requestImageCreation($this->userId, $prompt, $model, count($resources));
 			$urls = array_map(static function (array $result) {
 				return $result['url'] ?? null;
 			}, $apiResponse['data']);

--- a/lib/Service/OpenAiAPIService.php
+++ b/lib/Service/OpenAiAPIService.php
@@ -511,26 +511,26 @@ class OpenAiAPIService {
 	/**
 	 * @param string|null $userId
 	 * @param string $prompt
+	 * @param string $model
 	 * @param int $n
 	 * @param string $size
 	 * @return array
 	 * @throws Exception
 	 */
-	public function requestImageCreation(?string $userId, string $prompt, int $n = 1, string $size = Application::DEFAULT_IMAGE_SIZE): array {
+	public function requestImageCreation(
+		?string $userId, string $prompt, string $model, int $n = 1, string $size = Application::DEFAULT_IMAGE_SIZE
+	): array {
 		if ($this->isQuotaExceeded($userId, Application::QUOTA_TYPE_IMAGE)) {
 			throw new Exception($this->l10n->t('Image generation quota exceeded'), Http::STATUS_TOO_MANY_REQUESTS);
 		}
 
-		$model = $this->config->getAppValue(Application::APP_ID, 'default_image_model_id') ?: Application::DEFAULT_MODEL_ID;
 		$params = [
 			'prompt' => $prompt,
 			'size' => $size,
 			'n' => $n,
 			'response_format' => 'url',
+			'model' => $model === Application::DEFAULT_MODEL_ID ? Application::DEFAULT_IMAGE_MODEL_ID : $model,
 		];
-		if ($model !== Application::DEFAULT_MODEL_ID) {
-			$params['model'] = $model;
-		}
 
 		$apiResponse = $this->request($userId, 'images/generations', $params, 'POST');
 

--- a/lib/TaskProcessing/ContextWriteProvider.php
+++ b/lib/TaskProcessing/ContextWriteProvider.php
@@ -58,15 +58,28 @@ class ContextWriteProvider implements ISynchronousProvider {
 				$this->l->t('The maximum number of words/tokens that can be generated in the completion.'),
 				EShapeType::Number
 			),
+			'model' => new ShapeDescriptor(
+				$this->l->t('Model'),
+				$this->l->t('The model used to generate the completion'),
+				EShapeType::Enum
+			),
 		];
 	}
 
 	public function getOptionalInputShapeEnumValues(): array {
-		return [];
+		return [
+			'model' => $this->openAiAPIService->getModelEnumValues($this->userId),
+		];
 	}
 
 	public function getOptionalInputShapeDefaults(): array {
-		return [];
+		$adminModel = $this->openAiAPIService->isUsingOpenAi()
+			? ($this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID)
+			: $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id');
+		return [
+			'max_tokens' => 1000,
+			'model' => $adminModel,
+		];
 	}
 
 	public function getOutputShapeEnumValues(): array {
@@ -83,7 +96,6 @@ class ContextWriteProvider implements ISynchronousProvider {
 
 	public function process(?string $userId, array $input, callable $reportProgress): array {
 		$startTime = time();
-		$adminModel = $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_COMPLETION_MODEL_ID) ?: Application::DEFAULT_COMPLETION_MODEL_ID;
 
 		if (
 			!isset($input['style_input']) || !is_string($input['style_input'])
@@ -108,11 +120,17 @@ class ContextWriteProvider implements ISynchronousProvider {
 			$maxTokens = $input['max_tokens'];
 		}
 
+		if (isset($input['model']) && is_string($input['model'])) {
+			$model = $input['model'];
+		} else {
+			$model = $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID;
+		}
+
 		try {
 			if ($this->openAiAPIService->isUsingOpenAi() || $this->openAiSettingsService->getChatEndpointEnabled()) {
-				$completion = $this->openAiAPIService->createChatCompletion($this->userId, $adminModel, $prompt, null, null, 1, $maxTokens);
+				$completion = $this->openAiAPIService->createChatCompletion($this->userId, $model, $prompt, null, null, 1, $maxTokens);
 			} else {
-				$completion = $this->openAiAPIService->createCompletion($this->userId, $prompt, 1, $adminModel, $maxTokens);
+				$completion = $this->openAiAPIService->createCompletion($this->userId, $prompt, 1, $model, $maxTokens);
 			}
 		} catch (Exception $e) {
 			throw new RuntimeException('OpenAI/LocalAI request failed: ' . $e->getMessage());

--- a/lib/TaskProcessing/HeadlineProvider.php
+++ b/lib/TaskProcessing/HeadlineProvider.php
@@ -58,15 +58,28 @@ class HeadlineProvider implements ISynchronousProvider {
 				$this->l->t('The maximum number of words/tokens that can be generated in the completion.'),
 				EShapeType::Number
 			),
+			'model' => new ShapeDescriptor(
+				$this->l->t('Model'),
+				$this->l->t('The model used to generate the completion'),
+				EShapeType::Enum
+			),
 		];
 	}
 
 	public function getOptionalInputShapeEnumValues(): array {
-		return [];
+		return [
+			'model' => $this->openAiAPIService->getModelEnumValues($this->userId),
+		];
 	}
 
 	public function getOptionalInputShapeDefaults(): array {
-		return [];
+		$adminModel = $this->openAiAPIService->isUsingOpenAi()
+			? ($this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID)
+			: $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id');
+		return [
+			'max_tokens' => 1000,
+			'model' => $adminModel,
+		];
 	}
 
 	public function getOutputShapeEnumValues(): array {
@@ -83,7 +96,6 @@ class HeadlineProvider implements ISynchronousProvider {
 
 	public function process(?string $userId, array $input, callable $reportProgress): array {
 		$startTime = time();
-		$adminModel = $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_COMPLETION_MODEL_ID) ?: Application::DEFAULT_COMPLETION_MODEL_ID;
 
 		if (!isset($input['input']) || !is_string($input['input'])) {
 			throw new RuntimeException('Invalid prompt');
@@ -96,11 +108,17 @@ class HeadlineProvider implements ISynchronousProvider {
 			$maxTokens = $input['max_tokens'];
 		}
 
+		if (isset($input['model']) && is_string($input['model'])) {
+			$model = $input['model'];
+		} else {
+			$model = $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID;
+		}
+
 		try {
 			if ($this->openAiAPIService->isUsingOpenAi() || $this->openAiSettingsService->getChatEndpointEnabled()) {
-				$completion = $this->openAiAPIService->createChatCompletion($this->userId, $adminModel, $prompt, null, null, 1, $maxTokens);
+				$completion = $this->openAiAPIService->createChatCompletion($this->userId, $model, $prompt, null, null, 1, $maxTokens);
 			} else {
-				$completion = $this->openAiAPIService->createCompletion($this->userId, $prompt, 1, $adminModel, $maxTokens);
+				$completion = $this->openAiAPIService->createCompletion($this->userId, $prompt, 1, $model, $maxTokens);
 			}
 		} catch (Exception $e) {
 			throw new RuntimeException('OpenAI/LocalAI request failed: ' . $e->getMessage());

--- a/lib/TaskProcessing/SummaryProvider.php
+++ b/lib/TaskProcessing/SummaryProvider.php
@@ -58,15 +58,28 @@ class SummaryProvider implements ISynchronousProvider {
 				$this->l->t('The maximum number of words/tokens that can be generated in the completion.'),
 				EShapeType::Number
 			),
+			'model' => new ShapeDescriptor(
+				$this->l->t('Model'),
+				$this->l->t('The model used to generate the completion'),
+				EShapeType::Enum
+			),
 		];
 	}
 
 	public function getOptionalInputShapeEnumValues(): array {
-		return [];
+		return [
+			'model' => $this->openAiAPIService->getModelEnumValues($this->userId),
+		];
 	}
 
 	public function getOptionalInputShapeDefaults(): array {
-		return [];
+		$adminModel = $this->openAiAPIService->isUsingOpenAi()
+			? ($this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID)
+			: $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id');
+		return [
+			'max_tokens' => 1000,
+			'model' => $adminModel,
+		];
 	}
 
 	public function getOutputShapeEnumValues(): array {
@@ -83,7 +96,6 @@ class SummaryProvider implements ISynchronousProvider {
 
 	public function process(?string $userId, array $input, callable $reportProgress): array {
 		$startTime = time();
-		$adminModel = $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_COMPLETION_MODEL_ID) ?: Application::DEFAULT_COMPLETION_MODEL_ID;
 
 		if (!isset($input['input']) || !is_string($input['input'])) {
 			throw new RuntimeException('Invalid prompt');
@@ -96,11 +108,17 @@ class SummaryProvider implements ISynchronousProvider {
 			$maxTokens = $input['max_tokens'];
 		}
 
+		if (isset($input['model']) && is_string($input['model'])) {
+			$model = $input['model'];
+		} else {
+			$model = $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID;
+		}
+
 		try {
 			if ($this->openAiAPIService->isUsingOpenAi() || $this->openAiSettingsService->getChatEndpointEnabled()) {
-				$completion = $this->openAiAPIService->createChatCompletion($this->userId, $adminModel, $prompt, null, null, 1, $maxTokens);
+				$completion = $this->openAiAPIService->createChatCompletion($this->userId, $model, $prompt, null, null, 1, $maxTokens);
 			} else {
-				$completion = $this->openAiAPIService->createCompletion($this->userId, $prompt, 1, $adminModel, $maxTokens);
+				$completion = $this->openAiAPIService->createCompletion($this->userId, $prompt, 1, $model, $maxTokens);
 			}
 		} catch (Exception $e) {
 			throw new RuntimeException('OpenAI/LocalAI request failed: ' . $e->getMessage());

--- a/lib/TaskProcessing/TextToImageProvider.php
+++ b/lib/TaskProcessing/TextToImageProvider.php
@@ -12,7 +12,6 @@ use OCP\IL10N;
 use OCP\TaskProcessing\EShapeType;
 use OCP\TaskProcessing\ISynchronousProvider;
 use OCP\TaskProcessing\ShapeDescriptor;
-use OCP\TaskProcessing\ShapeEnumValue;
 use OCP\TaskProcessing\TaskTypes\TextToImage;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
@@ -73,24 +72,9 @@ class TextToImageProvider implements ISynchronousProvider {
 	}
 
 	public function getOptionalInputShapeEnumValues(): array {
-		if ($this->userId === null) {
-			return [];
-		}
-		try {
-			$modelResponse = $this->openAiAPIService->getModels($this->userId);
-			$modelEnumValues = array_map(function (array $model) {
-				return new ShapeEnumValue($model['id'], $model['id']);
-			}, $modelResponse['data'] ?? []);
-			if ($this->openAiAPIService->isUsingOpenAi()) {
-				array_unshift($modelEnumValues, new ShapeEnumValue($this->l->t('Default'), 'Default'));
-			}
-			return [
-				'model' => $modelEnumValues,
-			];
-		} catch (\Throwable $e) {
-			$this->logger->warning('Error in TextToImageProvider', ['exception' => $e]);
-			return [];
-		}
+		return [
+			'model' => $this->openAiAPIService->getModelEnumValues($this->userId),
+		];
 	}
 
 	public function getOptionalInputShapeDefaults(): array {

--- a/lib/TaskProcessing/TextToImageProvider.php
+++ b/lib/TaskProcessing/TextToImageProvider.php
@@ -7,10 +7,12 @@ namespace OCA\OpenAi\TaskProcessing;
 use OCA\OpenAi\AppInfo\Application;
 use OCA\OpenAi\Service\OpenAiAPIService;
 use OCP\Http\Client\IClientService;
+use OCP\IConfig;
 use OCP\IL10N;
 use OCP\TaskProcessing\EShapeType;
 use OCP\TaskProcessing\ISynchronousProvider;
 use OCP\TaskProcessing\ShapeDescriptor;
+use OCP\TaskProcessing\ShapeEnumValue;
 use OCP\TaskProcessing\TaskTypes\TextToImage;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
@@ -22,6 +24,8 @@ class TextToImageProvider implements ISynchronousProvider {
 		private IL10N $l,
 		private LoggerInterface $logger,
 		private IClientService $clientService,
+		private IConfig $config,
+		private ?string $userId,
 	) {
 	}
 
@@ -60,15 +64,42 @@ class TextToImageProvider implements ISynchronousProvider {
 				$this->l->t('Optional. The size of the generated images. Must be in 256x256 format.'),
 				EShapeType::Text
 			),
+			'model' => new ShapeDescriptor(
+				$this->l->t('Model'),
+				$this->l->t('The model used to generate the images'),
+				EShapeType::Enum
+			),
 		];
 	}
 
 	public function getOptionalInputShapeEnumValues(): array {
-		return [];
+		if ($this->userId === null) {
+			return [];
+		}
+		try {
+			$modelResponse = $this->openAiAPIService->getModels($this->userId);
+			$modelEnumValues = array_map(function (array $model) {
+				return new ShapeEnumValue($model['id'], $model['id']);
+			}, $modelResponse['data'] ?? []);
+			if ($this->openAiAPIService->isUsingOpenAi()) {
+				array_unshift($modelEnumValues, new ShapeEnumValue($this->l->t('Default'), 'Default'));
+			}
+			return [
+				'model' => $modelEnumValues,
+			];
+		} catch (\Throwable $e) {
+			$this->logger->warning('Error in TextToImageProvider', ['exception' => $e]);
+			return [];
+		}
 	}
 
 	public function getOptionalInputShapeDefaults(): array {
-		return [];
+		$adminModel = $this->openAiAPIService->isUsingOpenAi()
+			? ($this->config->getAppValue(Application::APP_ID, 'default_image_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID)
+			: $this->config->getAppValue(Application::APP_ID, 'default_image_model_id');
+		return [
+			'model' => $adminModel,
+		];
 	}
 
 	public function getOutputShapeEnumValues(): array {
@@ -101,8 +132,14 @@ class TextToImageProvider implements ISynchronousProvider {
 			$size = trim($input['size']);
 		}
 
+		if (isset($input['model']) && is_string($input['model'])) {
+			$model = $input['model'];
+		} else {
+			$model = $this->config->getAppValue(Application::APP_ID, 'default_image_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID;
+		}
+
 		try {
-			$apiResponse = $this->openAiAPIService->requestImageCreation($userId, $prompt, $nbImages, $size);
+			$apiResponse = $this->openAiAPIService->requestImageCreation($userId, $prompt, $model, $nbImages, $size);
 			$urls = array_map(static function (array $result) {
 				return $result['url'] ?? null;
 			}, $apiResponse['data']);

--- a/lib/TaskProcessing/TextToTextProvider.php
+++ b/lib/TaskProcessing/TextToTextProvider.php
@@ -78,6 +78,9 @@ class TextToTextProvider implements ISynchronousProvider {
 			$modelEnumValues = array_map(function (array $model) {
 				return new ShapeEnumValue($model['id'], $model['id']);
 			}, $modelResponse['data'] ?? []);
+			if ($this->openAiAPIService->isUsingOpenAi()) {
+				array_unshift($modelEnumValues, new ShapeEnumValue($this->l->t('Default'), 'Default'));
+			}
 			return [
 				'model' => $modelEnumValues,
 			];
@@ -88,7 +91,9 @@ class TextToTextProvider implements ISynchronousProvider {
 	}
 
 	public function getOptionalInputShapeDefaults(): array {
-		$adminModel = $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_COMPLETION_MODEL_ID) ?: Application::DEFAULT_COMPLETION_MODEL_ID;
+		$adminModel = $this->openAiAPIService->isUsingOpenAi()
+			? ($this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID)
+			: $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id');
 		return [
 			'max_tokens' => 1000,
 			'model' => $adminModel,
@@ -119,7 +124,7 @@ class TextToTextProvider implements ISynchronousProvider {
 		if (isset($input['model']) && is_string($input['model'])) {
 			$model = $input['model'];
 		} else {
-			$model = $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_COMPLETION_MODEL_ID) ?: Application::DEFAULT_COMPLETION_MODEL_ID;
+			$model = $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID;
 		}
 
 		if (!isset($input['input']) || !is_string($input['input'])) {

--- a/lib/TaskProcessing/TextToTextProvider.php
+++ b/lib/TaskProcessing/TextToTextProvider.php
@@ -13,9 +13,7 @@ use OCP\IL10N;
 use OCP\TaskProcessing\EShapeType;
 use OCP\TaskProcessing\ISynchronousProvider;
 use OCP\TaskProcessing\ShapeDescriptor;
-use OCP\TaskProcessing\ShapeEnumValue;
 use OCP\TaskProcessing\TaskTypes\TextToText;
-use Psr\Log\LoggerInterface;
 use RuntimeException;
 
 class TextToTextProvider implements ISynchronousProvider {
@@ -26,7 +24,6 @@ class TextToTextProvider implements ISynchronousProvider {
 		private OpenAiSettingsService $openAiSettingsService,
 		private IL10N $l,
 		private ?string $userId,
-		private LoggerInterface $logger,
 	) {
 	}
 
@@ -70,24 +67,9 @@ class TextToTextProvider implements ISynchronousProvider {
 	}
 
 	public function getOptionalInputShapeEnumValues(): array {
-		if ($this->userId === null) {
-			return [];
-		}
-		try {
-			$modelResponse = $this->openAiAPIService->getModels($this->userId);
-			$modelEnumValues = array_map(function (array $model) {
-				return new ShapeEnumValue($model['id'], $model['id']);
-			}, $modelResponse['data'] ?? []);
-			if ($this->openAiAPIService->isUsingOpenAi()) {
-				array_unshift($modelEnumValues, new ShapeEnumValue($this->l->t('Default'), 'Default'));
-			}
-			return [
-				'model' => $modelEnumValues,
-			];
-		} catch (\Throwable $e) {
-			$this->logger->warning('Error in TextToTextProvider', ['exception' => $e]);
-			return [];
-		}
+		return [
+			'model' => $this->openAiAPIService->getModelEnumValues($this->userId),
+		];
 	}
 
 	public function getOptionalInputShapeDefaults(): array {
@@ -121,12 +103,6 @@ class TextToTextProvider implements ISynchronousProvider {
 		}
 		*/
 		$startTime = time();
-		if (isset($input['model']) && is_string($input['model'])) {
-			$model = $input['model'];
-		} else {
-			$model = $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID;
-		}
-
 		if (!isset($input['input']) || !is_string($input['input'])) {
 			throw new RuntimeException('Invalid prompt');
 		}
@@ -135,6 +111,12 @@ class TextToTextProvider implements ISynchronousProvider {
 		$maxTokens = null;
 		if (isset($input['max_tokens']) && is_int($input['max_tokens'])) {
 			$maxTokens = $input['max_tokens'];
+		}
+
+		if (isset($input['model']) && is_string($input['model'])) {
+			$model = $input['model'];
+		} else {
+			$model = $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID;
 		}
 
 		try {

--- a/lib/TaskProcessing/TopicsProvider.php
+++ b/lib/TaskProcessing/TopicsProvider.php
@@ -58,15 +58,28 @@ class TopicsProvider implements ISynchronousProvider {
 				$this->l->t('The maximum number of words/tokens that can be generated in the completion.'),
 				EShapeType::Number
 			),
+			'model' => new ShapeDescriptor(
+				$this->l->t('Model'),
+				$this->l->t('The model used to generate the completion'),
+				EShapeType::Enum
+			),
 		];
 	}
 
 	public function getOptionalInputShapeEnumValues(): array {
-		return [];
+		return [
+			'model' => $this->openAiAPIService->getModelEnumValues($this->userId),
+		];
 	}
 
 	public function getOptionalInputShapeDefaults(): array {
-		return [];
+		$adminModel = $this->openAiAPIService->isUsingOpenAi()
+			? ($this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID)
+			: $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id');
+		return [
+			'max_tokens' => 1000,
+			'model' => $adminModel,
+		];
 	}
 
 	public function getOutputShapeEnumValues(): array {
@@ -83,7 +96,6 @@ class TopicsProvider implements ISynchronousProvider {
 
 	public function process(?string $userId, array $input, callable $reportProgress): array {
 		$startTime = time();
-		$adminModel = $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_COMPLETION_MODEL_ID) ?: Application::DEFAULT_COMPLETION_MODEL_ID;
 
 		if (!isset($input['input']) || !is_string($input['input'])) {
 			throw new RuntimeException('Invalid prompt');
@@ -96,11 +108,17 @@ class TopicsProvider implements ISynchronousProvider {
 			$maxTokens = $input['max_tokens'];
 		}
 
+		if (isset($input['model']) && is_string($input['model'])) {
+			$model = $input['model'];
+		} else {
+			$model = $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID;
+		}
+
 		try {
 			if ($this->openAiAPIService->isUsingOpenAi() || $this->openAiSettingsService->getChatEndpointEnabled()) {
-				$completion = $this->openAiAPIService->createChatCompletion($this->userId, $adminModel, $prompt, null, null, 1, $maxTokens);
+				$completion = $this->openAiAPIService->createChatCompletion($this->userId, $model, $prompt, null, null, 1, $maxTokens);
 			} else {
-				$completion = $this->openAiAPIService->createCompletion($this->userId, $prompt, 1, $adminModel, $maxTokens);
+				$completion = $this->openAiAPIService->createCompletion($this->userId, $prompt, 1, $model, $maxTokens);
 			}
 		} catch (Exception $e) {
 			throw new RuntimeException('OpenAI/LocalAI request failed: ' . $e->getMessage());

--- a/lib/TaskProcessing/TranslateProvider.php
+++ b/lib/TaskProcessing/TranslateProvider.php
@@ -85,24 +85,9 @@ class TranslateProvider implements ISynchronousProvider {
 	}
 
 	public function getOptionalInputShapeEnumValues(): array {
-		if ($this->userId === null) {
-			return [];
-		}
-		try {
-			$modelResponse = $this->openAiAPIService->getModels($this->userId);
-			$modelEnumValues = array_map(function (array $model) {
-				return new ShapeEnumValue($model['id'], $model['id']);
-			}, $modelResponse['data'] ?? []);
-			if ($this->openAiAPIService->isUsingOpenAi()) {
-				array_unshift($modelEnumValues, new ShapeEnumValue($this->l->t('Default'), 'Default'));
-			}
-			return [
-				'model' => $modelEnumValues,
-			];
-		} catch (\Throwable $e) {
-			$this->logger->warning('Error in TranslateProvider', ['exception' => $e]);
-			return [];
-		}
+		return [
+			'model' => $this->openAiAPIService->getModelEnumValues($this->userId),
+		];
 	}
 
 	public function getOptionalInputShapeDefaults(): array {
@@ -148,7 +133,7 @@ class TranslateProvider implements ISynchronousProvider {
 		if (isset($input['model']) && is_string($input['model'])) {
 			$model = $input['model'];
 		} else {
-			$model = $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_COMPLETION_MODEL_ID) ?: Application::DEFAULT_COMPLETION_MODEL_ID;
+			$model = $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID;
 		}
 
 		if (!isset($input['input']) || !is_string($input['input'])) {

--- a/lib/TaskProcessing/TranslateProvider.php
+++ b/lib/TaskProcessing/TranslateProvider.php
@@ -93,6 +93,9 @@ class TranslateProvider implements ISynchronousProvider {
 			$modelEnumValues = array_map(function (array $model) {
 				return new ShapeEnumValue($model['id'], $model['id']);
 			}, $modelResponse['data'] ?? []);
+			if ($this->openAiAPIService->isUsingOpenAi()) {
+				array_unshift($modelEnumValues, new ShapeEnumValue($this->l->t('Default'), 'Default'));
+			}
 			return [
 				'model' => $modelEnumValues,
 			];
@@ -103,7 +106,9 @@ class TranslateProvider implements ISynchronousProvider {
 	}
 
 	public function getOptionalInputShapeDefaults(): array {
-		$adminModel = $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_COMPLETION_MODEL_ID) ?: Application::DEFAULT_COMPLETION_MODEL_ID;
+		$adminModel = $this->openAiAPIService->isUsingOpenAi()
+			? ($this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID)
+			: $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id');
 		return [
 			'max_tokens' => 1000,
 			'model' => $adminModel,

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -506,6 +506,8 @@ export default {
 
 					this.selectedModel.text = this.modelToNcSelectObject(completionModelToSelect)
 					this.selectedModel.image = this.modelToNcSelectObject(imageModelToSelect)
+					this.state.default_completion_model_id = completionModelToSelect.id
+					this.state.default_image_model_id = imageModelToSelect.id
 
 					if (save) {
 						this.saveOptions({

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -689,6 +689,7 @@ export default {
 
 	.model-select {
 		min-width: 350px;
+		margin: 0 !important;
 	}
 }
 </style>

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -480,7 +480,7 @@ export default {
 			}
 		},
 
-		getModels(save = true) {
+		getModels(shouldSave = true) {
 			this.models = null
 			if (!this.configured) {
 				return
@@ -506,15 +506,19 @@ export default {
 
 					this.selectedModel.text = this.modelToNcSelectObject(completionModelToSelect)
 					this.selectedModel.image = this.modelToNcSelectObject(imageModelToSelect)
-					this.state.default_completion_model_id = completionModelToSelect.id
-					this.state.default_image_model_id = imageModelToSelect.id
 
-					if (save) {
+					// save if url/credentials were changed OR if the values are not up-to-date in the stored settings
+					if (shouldSave
+						|| this.state.default_completion_model_id !== this.selectedModel.text.id
+						|| this.state.default_image_model_id !== this.selectedModel.image.id) {
 						this.saveOptions({
 							default_completion_model_id: this.selectedModel.text.id,
 							default_image_model_id: this.selectedModel.image.id,
 						}, false)
 					}
+
+					this.state.default_completion_model_id = completionModelToSelect.id
+					this.state.default_image_model_id = imageModelToSelect.id
 				})
 				.catch((error) => {
 					showError(t('integration_openai', 'Failed to load models'))

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -50,7 +50,7 @@
 						type="text"
 						:readonly="readonly"
 						:placeholder="t('integration_openai', 'your Basic Auth user')"
-						@input="onInput"
+						@input="onSensitiveInput"
 						@focus="readonly = false">
 				</div>
 				<div class="line">
@@ -157,11 +157,12 @@ export default {
 	methods: {
 		onInput: debounce(function() {
 			this.saveOptions({
-				basic_user: this.state.basic_user,
 			})
 		}, 2000),
 		onSensitiveInput: debounce(function() {
-			const values = {}
+			const values = {
+				basic_user: this.state.basic_user,
+			}
 			if (this.state.api_key !== 'dummyApiKey') {
 				values.api_key = this.state.api_key
 			}


### PR DESCRIPTION
* Cleanup admin and user settings
    * Consider all credential/urls as sensitive
    * Always save default models after getting them when credentials/URL have changed
* Fix default model enum values in TaskProcessing providers
* Harmonize default model selection between text and image generation
* Add "model" optional input shape in all text and image generation task types
* Make sure default models are saved if they are not up-to-date when browsing the admin settings (cc @szaimen)

closes #129