### PR TITLE
Switch to IAppConfig

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -79,7 +79,7 @@ Negative:
 
 Learn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud.com/blog/nextcloud-ethical-ai-rating/).
 ]]>	</description>
-	<version>3.1.3</version>
+	<version>3.1.4</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>OpenAi</namespace>

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -31,7 +31,9 @@ use OCP\AppFramework\Bootstrap\IBootContext;
 
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
+use OCP\IAppConfig;
 use OCP\IConfig;
+use Psr\Container\ContainerInterface;
 
 class Application extends App implements IBootstrap {
 	public const APP_ID = 'integration_openai';
@@ -70,42 +72,42 @@ class Application extends App implements IBootstrap {
 	public const PROMPT_TYPE_TEXT = 1;
 	public const MAX_PROMPT_PER_TYPE_PER_USER = 5;
 
-	private IConfig $config;
+	private IAppConfig $appConfig;
 
 	public function __construct(array $urlParams = []) {
 		parent::__construct(self::APP_ID, $urlParams);
 
 		$container = $this->getContainer();
-		$this->config = $container->query(IConfig::class);
+		$this->appConfig = $container->get(IAppConfig::class);
 	}
 
 	public function register(IRegistrationContext $context): void {
 		// deprecated APIs
-		if ($this->config->getAppValue(Application::APP_ID, 'translation_provider_enabled', '1') === '1') {
+		if ($this->appConfig->getValueString(Application::APP_ID, 'translation_provider_enabled', '1') === '1') {
 			$context->registerTranslationProvider(OldTranslationProvider::class);
 		}
-		if ($this->config->getAppValue(Application::APP_ID, 'stt_provider_enabled', '1') === '1') {
+		if ($this->appConfig->getValueString(Application::APP_ID, 'stt_provider_enabled', '1') === '1') {
 			$context->registerSpeechToTextProvider(OldSTTProvider::class);
 		}
 
-		if ($this->config->getAppValue(Application::APP_ID, 'llm_provider_enabled', '1') === '1') {
+		if ($this->appConfig->getValueString(Application::APP_ID, 'llm_provider_enabled', '1') === '1') {
 			$context->registerTextProcessingProvider(OldFreePromptProvider::class);
 			$context->registerTextProcessingProvider(OldSummaryProvider::class);
 			$context->registerTextProcessingProvider(OldHeadlineProvider::class);
 		}
-		if ($this->config->getAppValue(Application::APP_ID, 't2i_provider_enabled', '1') === '1') {
+		if ($this->appConfig->getValueString(Application::APP_ID, 't2i_provider_enabled', '1') === '1') {
 			$context->registerTextToImageProvider(OldTextToImageProvider::class);
 		}
 
 		// Task processing
-		if ($this->config->getAppValue(Application::APP_ID, 'translation_provider_enabled', '1') === '1') {
+		if ($this->appConfig->getValueString(Application::APP_ID, 'translation_provider_enabled', '1') === '1') {
 			$context->registerTaskProcessingProvider(TranslateProvider::class);
 		}
-		if ($this->config->getAppValue(Application::APP_ID, 'stt_provider_enabled', '1') === '1') {
+		if ($this->appConfig->getValueString(Application::APP_ID, 'stt_provider_enabled', '1') === '1') {
 			$context->registerTaskProcessingProvider(AudioToTextProvider::class);
 		}
 
-		if ($this->config->getAppValue(Application::APP_ID, 'llm_provider_enabled', '1') === '1') {
+		if ($this->appConfig->getValueString(Application::APP_ID, 'llm_provider_enabled', '1') === '1') {
 			$context->registerTaskProcessingProvider(TextToTextProvider::class);
 			$context->registerTaskProcessingProvider(TextToTextChatProvider::class);
 			$context->registerTaskProcessingProvider(SummaryProvider::class);
@@ -114,7 +116,7 @@ class Application extends App implements IBootstrap {
 			$context->registerTaskProcessingProvider(ContextWriteProvider::class);
 			$context->registerTaskProcessingProvider(ReformulateProvider::class);
 		}
-		if ($this->config->getAppValue(Application::APP_ID, 't2i_provider_enabled', '1') === '1') {
+		if ($this->appConfig->getValueString(Application::APP_ID, 't2i_provider_enabled', '1') === '1') {
 			$context->registerTaskProcessingProvider(TextToImageProvider::class);
 		}
 

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -32,8 +32,6 @@ use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\IAppConfig;
-use OCP\IConfig;
-use Psr\Container\ContainerInterface;
 
 class Application extends App implements IBootstrap {
 	public const APP_ID = 'integration_openai';

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -20,7 +20,6 @@ use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\PasswordConfirmationRequired;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\IRequest;
-use OCP\PreConditionNotMetException;
 
 class ConfigController extends Controller {
 	public function __construct(

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -37,7 +37,6 @@ class ConfigController extends Controller {
 	 *
 	 * @param array $values key/value pairs to store in config
 	 * @return DataResponse
-	 * @throws PreConditionNotMetException
 	 */
 	#[NoAdminRequired]
 	public function setUserConfig(array $values): DataResponse {
@@ -57,7 +56,6 @@ class ConfigController extends Controller {
 	 *
 	 * @param array $values key/value pairs to store in config
 	 * @return DataResponse
-	 * @throws PreConditionNotMetException
 	 */
 	#[NoAdminRequired]
 	#[PasswordConfirmationRequired]

--- a/lib/Cron/CleanupQuotaDb.php
+++ b/lib/Cron/CleanupQuotaDb.php
@@ -29,7 +29,7 @@ use OCA\OpenAi\AppInfo\Application;
 use OCA\OpenAi\Db\QuotaUsageMapper;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
-use OCP\IConfig;
+use OCP\IAppConfig;
 use Psr\Log\LoggerInterface;
 
 class CleanupQuotaDb extends TimedJob {
@@ -37,7 +37,7 @@ class CleanupQuotaDb extends TimedJob {
 		ITimeFactory $time,
 		private QuotaUsageMapper $quotaUsageMapper,
 		private LoggerInterface $logger,
-		private IConfig $config
+		private IAppConfig $appConfig,
 	) {
 		parent::__construct($time);
 		$this->setInterval(60 * 60 * 24); // Daily
@@ -49,7 +49,7 @@ class CleanupQuotaDb extends TimedJob {
 			// The mimimum period is limited to DEFAULT_QUOTA_PERIOD to not lose
 			// the stored quota usage data below this limit.
 			max(
-				intval($this->config->getAppValue(
+				intval($this->appConfig->getValueString(
 					Application::APP_ID,
 					'quota_period',
 					strval(Application::DEFAULT_QUOTA_PERIOD)

--- a/lib/Migration/Version030102Date20241003155512.php
+++ b/lib/Migration/Version030102Date20241003155512.php
@@ -11,7 +11,7 @@ namespace OCA\OpenAi\Migration;
 use Closure;
 use OCA\OpenAi\AppInfo\Application;
 use OCP\DB\QueryBuilder\IQueryBuilder;
-use OCP\IConfig;
+use OCP\IAppConfig;
 use OCP\IDBConnection;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
@@ -22,7 +22,7 @@ class Version030102Date20241003155512 extends SimpleMigrationStep {
 	public function __construct(
 		private IDBConnection $connection,
 		private ICrypto $crypto,
-		private IConfig $config,
+		private IAppConfig $appConfig,
 	) {
 	}
 
@@ -34,10 +34,10 @@ class Version030102Date20241003155512 extends SimpleMigrationStep {
 	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {
 		// app config
 		foreach (['api_key', 'basic_password'] as $key) {
-			$value = $this->config->getAppValue(Application::APP_ID, $key);
+			$value = $this->appConfig->getValueString(Application::APP_ID, $key);
 			if ($value !== '') {
 				$encryptedValue = $this->crypto->encrypt($value);
-				$this->config->setAppValue(Application::APP_ID, $key, $encryptedValue);
+				$this->appConfig->setValueString(Application::APP_ID, $key, $encryptedValue);
 			}
 		}
 

--- a/lib/Migration/Version030103Date20241009172829.php
+++ b/lib/Migration/Version030103Date20241009172829.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\OpenAi\Migration;
+
+use Closure;
+use OCA\OpenAi\AppInfo\Application;
+use OCP\IAppConfig;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\Security\ICrypto;
+
+class Version030103Date20241009172829 extends SimpleMigrationStep {
+
+	public function __construct(
+		private ICrypto $crypto,
+		private IAppConfig $appConfig,
+	) {
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 */
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {
+		// switch from manually encrypted to automatically encrypted sensitive value with IAppConfig
+		foreach (['api_key', 'basic_password'] as $key) {
+			$value = $this->appConfig->getValueString(Application::APP_ID, $key);
+			if ($value !== '') {
+				$decryptedValue = $this->crypto->decrypt($value);
+				$this->appConfig->setValueString(Application::APP_ID, $key, $decryptedValue, false, true);
+			}
+		}
+	}
+}

--- a/lib/Service/OpenAiAPIService.php
+++ b/lib/Service/OpenAiAPIService.php
@@ -25,7 +25,7 @@ use OCP\Files\GenericFileException;
 use OCP\Files\NotPermittedException;
 use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
-use OCP\IConfig;
+use OCP\IAppConfig;
 use OCP\IL10N;
 use OCP\Lock\LockedException;
 use OCP\TaskProcessing\ShapeEnumValue;
@@ -42,7 +42,7 @@ class OpenAiAPIService {
 	public function __construct(
 		private LoggerInterface $logger,
 		private IL10N $l10n,
-		private IConfig $config,
+		private IAppConfig $appConfig,
 		private QuotaUsageMapper $quotaUsageMapper,
 		private OpenAiSettingsService $openAiSettingsService,
 		IClientService $clientService
@@ -438,7 +438,7 @@ class OpenAiAPIService {
 	 * @return array|null
 	 */
 	private function getAdminExtraParams(string $configKey): ?array {
-		$stringValue = $this->config->getAppValue(Application::APP_ID, $configKey);
+		$stringValue = $this->appConfig->getValueString(Application::APP_ID, $configKey);
 		if ($stringValue === '') {
 			return null;
 		}
@@ -609,8 +609,8 @@ class OpenAiAPIService {
 	 */
 	public function getExpTextProcessingTime(): int {
 		return $this->isUsingOpenAi()
-			? intval($this->config->getAppValue(Application::APP_ID, 'openai_text_generation_time', strval(Application::DEFAULT_OPENAI_TEXT_GENERATION_TIME)))
-			: intval($this->config->getAppValue(Application::APP_ID, 'localai_text_generation_time', strval(Application::DEFAULT_LOCALAI_TEXT_GENERATION_TIME)));
+			? intval($this->appConfig->getValueString(Application::APP_ID, 'openai_text_generation_time', strval(Application::DEFAULT_OPENAI_TEXT_GENERATION_TIME)))
+			: intval($this->appConfig->getValueString(Application::APP_ID, 'localai_text_generation_time', strval(Application::DEFAULT_LOCALAI_TEXT_GENERATION_TIME)));
 	}
 
 	/**
@@ -622,9 +622,9 @@ class OpenAiAPIService {
 		$newTime = (1 - Application::EXPECTED_RUNTIME_LOWPASS_FACTOR) * $oldTime + Application::EXPECTED_RUNTIME_LOWPASS_FACTOR * $runtime;
 
 		if ($this->isUsingOpenAi()) {
-			$this->config->setAppValue(Application::APP_ID, 'openai_text_generation_time', strval(intval($newTime)));
+			$this->appConfig->setValueString(Application::APP_ID, 'openai_text_generation_time', strval(intval($newTime)));
 		} else {
-			$this->config->setAppValue(Application::APP_ID, 'localai_text_generation_time', strval(intval($newTime)));
+			$this->appConfig->setValueString(Application::APP_ID, 'localai_text_generation_time', strval(intval($newTime)));
 		}
 	}
 
@@ -633,8 +633,8 @@ class OpenAiAPIService {
 	 */
 	public function getExpImgProcessingTime(): int {
 		return $this->isUsingOpenAi()
-			? intval($this->config->getAppValue(Application::APP_ID, 'openai_image_generation_time', strval(Application::DEFAULT_OPENAI_IMAGE_GENERATION_TIME)))
-			: intval($this->config->getAppValue(Application::APP_ID, 'localai_image_generation_time', strval(Application::DEFAULT_LOCALAI_IMAGE_GENERATION_TIME)));
+			? intval($this->appConfig->getValueString(Application::APP_ID, 'openai_image_generation_time', strval(Application::DEFAULT_OPENAI_IMAGE_GENERATION_TIME)))
+			: intval($this->appConfig->getValueString(Application::APP_ID, 'localai_image_generation_time', strval(Application::DEFAULT_LOCALAI_IMAGE_GENERATION_TIME)));
 	}
 
 	/**
@@ -646,9 +646,9 @@ class OpenAiAPIService {
 		$newTime = (1 - Application::EXPECTED_RUNTIME_LOWPASS_FACTOR) * $oldTime + Application::EXPECTED_RUNTIME_LOWPASS_FACTOR * $runtime;
 
 		if ($this->isUsingOpenAi()) {
-			$this->config->setAppValue(Application::APP_ID, 'openai_image_generation_time', strval(intval($newTime)));
+			$this->appConfig->setValueString(Application::APP_ID, 'openai_image_generation_time', strval(intval($newTime)));
 		} else {
-			$this->config->setAppValue(Application::APP_ID, 'localai_image_generation_time', strval(intval($newTime)));
+			$this->appConfig->setValueString(Application::APP_ID, 'localai_image_generation_time', strval(intval($newTime)));
 		}
 	}
 

--- a/lib/Service/OpenAiSettingsService.php
+++ b/lib/Service/OpenAiSettingsService.php
@@ -352,7 +352,7 @@ class OpenAiSettingsService {
 	 */
 	public function setAdminApiKey(string $apiKey): void {
 		// No need to validate. As long as it's a string, we're happy campers
-		$this->appConfig->setValueString(Application::APP_ID, 'api_key', $apiKey);
+		$this->appConfig->setValueString(Application::APP_ID, 'api_key', $apiKey, false, true);
 	}
 
 	/**
@@ -477,7 +477,7 @@ class OpenAiSettingsService {
 	 * @return void
 	 */
 	public function setAdminBasicPassword(string $basicPassword): void {
-		$this->appConfig->setValueString(Application::APP_ID, 'basic_password', $basicPassword);
+		$this->appConfig->setValueString(Application::APP_ID, 'basic_password', $basicPassword, false, true);
 	}
 
 	/**

--- a/lib/Service/OpenAiSettingsService.php
+++ b/lib/Service/OpenAiSettingsService.php
@@ -170,6 +170,9 @@ class OpenAiSettingsService {
 			) ?: json_encode(Application::DEFAULT_QUOTAS),
 			true,
 		);
+		if ($quotas === null) {
+			$quotas = Application::DEFAULT_QUOTAS;
+		}
 		// Make sure all quota types are set in the json encoded app value (in case new quota types are added in the future)
 		if (count($quotas) !== count(Application::DEFAULT_QUOTAS)) {
 			foreach (Application::DEFAULT_QUOTAS as $quotaType => $_) {
@@ -342,7 +345,7 @@ class OpenAiSettingsService {
 			}
 		}
 
-		$this->appConfig->setValueString(Application::APP_ID, 'quotas', json_encode($quotas));
+		$this->appConfig->setValueString(Application::APP_ID, 'quotas', json_encode($quotas, JSON_THROW_ON_ERROR));
 	}
 
 	/**

--- a/lib/Service/OpenAiSettingsService.php
+++ b/lib/Service/OpenAiSettingsService.php
@@ -25,7 +25,6 @@ namespace OCA\OpenAi\Service;
 
 use Exception;
 use OCA\OpenAi\AppInfo\Application;
-use OCP\Exceptions\AppConfigTypeConflictException;
 use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\PreConditionNotMetException;

--- a/lib/TaskProcessing/ContextWriteProvider.php
+++ b/lib/TaskProcessing/ContextWriteProvider.php
@@ -8,7 +8,7 @@ use Exception;
 use OCA\OpenAi\AppInfo\Application;
 use OCA\OpenAi\Service\OpenAiAPIService;
 use OCA\OpenAi\Service\OpenAiSettingsService;
-use OCP\IConfig;
+use OCP\IAppConfig;
 use OCP\IL10N;
 use OCP\TaskProcessing\EShapeType;
 use OCP\TaskProcessing\ISynchronousProvider;
@@ -20,7 +20,7 @@ class ContextWriteProvider implements ISynchronousProvider {
 
 	public function __construct(
 		private OpenAiAPIService $openAiAPIService,
-		private IConfig $config,
+		private IAppConfig $appConfig,
 		private OpenAiSettingsService $openAiSettingsService,
 		private IL10N $l,
 		private ?string $userId,
@@ -74,8 +74,8 @@ class ContextWriteProvider implements ISynchronousProvider {
 
 	public function getOptionalInputShapeDefaults(): array {
 		$adminModel = $this->openAiAPIService->isUsingOpenAi()
-			? ($this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID)
-			: $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id');
+			? ($this->appConfig->getValueString(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID)
+			: $this->appConfig->getValueString(Application::APP_ID, 'default_completion_model_id');
 		return [
 			'max_tokens' => 1000,
 			'model' => $adminModel,
@@ -123,7 +123,7 @@ class ContextWriteProvider implements ISynchronousProvider {
 		if (isset($input['model']) && is_string($input['model'])) {
 			$model = $input['model'];
 		} else {
-			$model = $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID;
+			$model = $this->appConfig->getValueString(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID;
 		}
 
 		try {

--- a/lib/TaskProcessing/HeadlineProvider.php
+++ b/lib/TaskProcessing/HeadlineProvider.php
@@ -8,7 +8,7 @@ use Exception;
 use OCA\OpenAi\AppInfo\Application;
 use OCA\OpenAi\Service\OpenAiAPIService;
 use OCA\OpenAi\Service\OpenAiSettingsService;
-use OCP\IConfig;
+use OCP\IAppConfig;
 use OCP\IL10N;
 use OCP\TaskProcessing\EShapeType;
 use OCP\TaskProcessing\ISynchronousProvider;
@@ -20,7 +20,7 @@ class HeadlineProvider implements ISynchronousProvider {
 
 	public function __construct(
 		private OpenAiAPIService $openAiAPIService,
-		private IConfig $config,
+		private IAppConfig $appConfig,
 		private OpenAiSettingsService $openAiSettingsService,
 		private IL10N $l,
 		private ?string $userId,
@@ -74,8 +74,8 @@ class HeadlineProvider implements ISynchronousProvider {
 
 	public function getOptionalInputShapeDefaults(): array {
 		$adminModel = $this->openAiAPIService->isUsingOpenAi()
-			? ($this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID)
-			: $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id');
+			? ($this->appConfig->getValueString(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID)
+			: $this->appConfig->getValueString(Application::APP_ID, 'default_completion_model_id');
 		return [
 			'max_tokens' => 1000,
 			'model' => $adminModel,
@@ -111,7 +111,7 @@ class HeadlineProvider implements ISynchronousProvider {
 		if (isset($input['model']) && is_string($input['model'])) {
 			$model = $input['model'];
 		} else {
-			$model = $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID;
+			$model = $this->appConfig->getValueString(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID;
 		}
 
 		try {

--- a/lib/TaskProcessing/ReformulateProvider.php
+++ b/lib/TaskProcessing/ReformulateProvider.php
@@ -8,6 +8,7 @@ use Exception;
 use OCA\OpenAi\AppInfo\Application;
 use OCA\OpenAi\Service\OpenAiAPIService;
 use OCA\OpenAi\Service\OpenAiSettingsService;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\TaskProcessing\EShapeType;
@@ -21,6 +22,7 @@ class ReformulateProvider implements ISynchronousProvider {
 	public function __construct(
 		private OpenAiAPIService $openAiAPIService,
 		private IConfig $config,
+		private IAppConfig $appConfig,
 		private OpenAiSettingsService $openAiSettingsService,
 		private IL10N $l,
 		private ?string $userId,
@@ -74,8 +76,8 @@ class ReformulateProvider implements ISynchronousProvider {
 
 	public function getOptionalInputShapeDefaults(): array {
 		$adminModel = $this->openAiAPIService->isUsingOpenAi()
-			? ($this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID)
-			: $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id');
+			? ($this->appConfig->getValueString(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID)
+			: $this->appConfig->getValueString(Application::APP_ID, 'default_completion_model_id');
 		return [
 			'max_tokens' => 1000,
 			'model' => $adminModel,
@@ -111,7 +113,7 @@ class ReformulateProvider implements ISynchronousProvider {
 		if (isset($input['model']) && is_string($input['model'])) {
 			$model = $input['model'];
 		} else {
-			$model = $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID;
+			$model = $this->appConfig->getValueString(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID;
 		}
 
 		try {

--- a/lib/TaskProcessing/ReformulateProvider.php
+++ b/lib/TaskProcessing/ReformulateProvider.php
@@ -9,7 +9,6 @@ use OCA\OpenAi\AppInfo\Application;
 use OCA\OpenAi\Service\OpenAiAPIService;
 use OCA\OpenAi\Service\OpenAiSettingsService;
 use OCP\IAppConfig;
-use OCP\IConfig;
 use OCP\IL10N;
 use OCP\TaskProcessing\EShapeType;
 use OCP\TaskProcessing\ISynchronousProvider;
@@ -21,7 +20,6 @@ class ReformulateProvider implements ISynchronousProvider {
 
 	public function __construct(
 		private OpenAiAPIService $openAiAPIService,
-		private IConfig $config,
 		private IAppConfig $appConfig,
 		private OpenAiSettingsService $openAiSettingsService,
 		private IL10N $l,

--- a/lib/TaskProcessing/SummaryProvider.php
+++ b/lib/TaskProcessing/SummaryProvider.php
@@ -8,7 +8,7 @@ use Exception;
 use OCA\OpenAi\AppInfo\Application;
 use OCA\OpenAi\Service\OpenAiAPIService;
 use OCA\OpenAi\Service\OpenAiSettingsService;
-use OCP\IConfig;
+use OCP\IAppConfig;
 use OCP\IL10N;
 use OCP\TaskProcessing\EShapeType;
 use OCP\TaskProcessing\ISynchronousProvider;
@@ -20,7 +20,7 @@ class SummaryProvider implements ISynchronousProvider {
 
 	public function __construct(
 		private OpenAiAPIService $openAiAPIService,
-		private IConfig $config,
+		private IAppConfig $appConfig,
 		private OpenAiSettingsService $openAiSettingsService,
 		private IL10N $l,
 		private ?string $userId,
@@ -74,8 +74,8 @@ class SummaryProvider implements ISynchronousProvider {
 
 	public function getOptionalInputShapeDefaults(): array {
 		$adminModel = $this->openAiAPIService->isUsingOpenAi()
-			? ($this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID)
-			: $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id');
+			? ($this->appConfig->getValueString(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID)
+			: $this->appConfig->getValueString(Application::APP_ID, 'default_completion_model_id');
 		return [
 			'max_tokens' => 1000,
 			'model' => $adminModel,
@@ -111,7 +111,7 @@ class SummaryProvider implements ISynchronousProvider {
 		if (isset($input['model']) && is_string($input['model'])) {
 			$model = $input['model'];
 		} else {
-			$model = $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID;
+			$model = $this->appConfig->getValueString(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID;
 		}
 
 		try {

--- a/lib/TaskProcessing/TextToImageProvider.php
+++ b/lib/TaskProcessing/TextToImageProvider.php
@@ -7,7 +7,7 @@ namespace OCA\OpenAi\TaskProcessing;
 use OCA\OpenAi\AppInfo\Application;
 use OCA\OpenAi\Service\OpenAiAPIService;
 use OCP\Http\Client\IClientService;
-use OCP\IConfig;
+use OCP\IAppConfig;
 use OCP\IL10N;
 use OCP\TaskProcessing\EShapeType;
 use OCP\TaskProcessing\ISynchronousProvider;
@@ -23,7 +23,7 @@ class TextToImageProvider implements ISynchronousProvider {
 		private IL10N $l,
 		private LoggerInterface $logger,
 		private IClientService $clientService,
-		private IConfig $config,
+		private IAppConfig $appConfig,
 		private ?string $userId,
 	) {
 	}
@@ -57,7 +57,7 @@ class TextToImageProvider implements ISynchronousProvider {
 	}
 
 	public function getOptionalInputShape(): array {
-		$defaultImageSize = $this->config->getAppValue(Application::APP_ID, 'default_image_size') ?: Application::DEFAULT_DEFAULT_IMAGE_SIZE;
+		$defaultImageSize = $this->appConfig->getValueString(Application::APP_ID, 'default_image_size') ?: Application::DEFAULT_DEFAULT_IMAGE_SIZE;
 		return [
 			'size' => new ShapeDescriptor(
 				$this->l->t('Size'),
@@ -80,8 +80,8 @@ class TextToImageProvider implements ISynchronousProvider {
 
 	public function getOptionalInputShapeDefaults(): array {
 		$adminModel = $this->openAiAPIService->isUsingOpenAi()
-			? ($this->config->getAppValue(Application::APP_ID, 'default_image_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID)
-			: $this->config->getAppValue(Application::APP_ID, 'default_image_model_id');
+			? ($this->appConfig->getValueString(Application::APP_ID, 'default_image_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID)
+			: $this->appConfig->getValueString(Application::APP_ID, 'default_image_model_id');
 		return [
 			'model' => $adminModel,
 		];
@@ -112,7 +112,7 @@ class TextToImageProvider implements ISynchronousProvider {
 			$nbImages = $input['numberOfImages'];
 		}
 
-		$size = $this->config->getAppValue(Application::APP_ID, 'default_image_size') ?: Application::DEFAULT_DEFAULT_IMAGE_SIZE;
+		$size = $this->appConfig->getValueString(Application::APP_ID, 'default_image_size') ?: Application::DEFAULT_DEFAULT_IMAGE_SIZE;
 		if (isset($input['size']) && is_string($input['size']) && preg_match('/^\d+x\d+$/', $input['size'])) {
 			$size = trim($input['size']);
 		}
@@ -120,7 +120,7 @@ class TextToImageProvider implements ISynchronousProvider {
 		if (isset($input['model']) && is_string($input['model'])) {
 			$model = $input['model'];
 		} else {
-			$model = $this->config->getAppValue(Application::APP_ID, 'default_image_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID;
+			$model = $this->appConfig->getValueString(Application::APP_ID, 'default_image_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID;
 		}
 
 		try {

--- a/lib/TaskProcessing/TextToTextChatProvider.php
+++ b/lib/TaskProcessing/TextToTextChatProvider.php
@@ -7,7 +7,7 @@ namespace OCA\OpenAi\TaskProcessing;
 use Exception;
 use OCA\OpenAi\AppInfo\Application;
 use OCA\OpenAi\Service\OpenAiAPIService;
-use OCP\IConfig;
+use OCP\IAppConfig;
 use OCP\IL10N;
 use OCP\TaskProcessing\EShapeType;
 use OCP\TaskProcessing\ISynchronousProvider;
@@ -19,7 +19,7 @@ class TextToTextChatProvider implements ISynchronousProvider {
 
 	public function __construct(
 		private OpenAiAPIService $openAiAPIService,
-		private IConfig $config,
+		private IAppConfig $appConfig,
 		private IL10N $l,
 		private ?string $userId,
 	) {
@@ -81,7 +81,7 @@ class TextToTextChatProvider implements ISynchronousProvider {
 
 	public function process(?string $userId, array $input, callable $reportProgress): array {
 		$startTime = time();
-		$adminModel = $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_COMPLETION_MODEL_ID) ?: Application::DEFAULT_COMPLETION_MODEL_ID;
+		$adminModel = $this->appConfig->getValueString(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_COMPLETION_MODEL_ID) ?: Application::DEFAULT_COMPLETION_MODEL_ID;
 
 		if (!isset($input['input']) || !is_string($input['input'])) {
 			throw new RuntimeException('Invalid input');

--- a/lib/TaskProcessing/TextToTextProvider.php
+++ b/lib/TaskProcessing/TextToTextProvider.php
@@ -8,7 +8,7 @@ use Exception;
 use OCA\OpenAi\AppInfo\Application;
 use OCA\OpenAi\Service\OpenAiAPIService;
 use OCA\OpenAi\Service\OpenAiSettingsService;
-use OCP\IConfig;
+use OCP\IAppConfig;
 use OCP\IL10N;
 use OCP\TaskProcessing\EShapeType;
 use OCP\TaskProcessing\ISynchronousProvider;
@@ -20,7 +20,7 @@ class TextToTextProvider implements ISynchronousProvider {
 
 	public function __construct(
 		private OpenAiAPIService $openAiAPIService,
-		private IConfig $config,
+		private IAppConfig $appConfig,
 		private OpenAiSettingsService $openAiSettingsService,
 		private IL10N $l,
 		private ?string $userId,
@@ -74,8 +74,8 @@ class TextToTextProvider implements ISynchronousProvider {
 
 	public function getOptionalInputShapeDefaults(): array {
 		$adminModel = $this->openAiAPIService->isUsingOpenAi()
-			? ($this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID)
-			: $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id');
+			? ($this->appConfig->getValueString(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID)
+			: $this->appConfig->getValueString(Application::APP_ID, 'default_completion_model_id');
 		return [
 			'max_tokens' => 1000,
 			'model' => $adminModel,
@@ -116,7 +116,7 @@ class TextToTextProvider implements ISynchronousProvider {
 		if (isset($input['model']) && is_string($input['model'])) {
 			$model = $input['model'];
 		} else {
-			$model = $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID;
+			$model = $this->appConfig->getValueString(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID;
 		}
 
 		try {

--- a/lib/TaskProcessing/TopicsProvider.php
+++ b/lib/TaskProcessing/TopicsProvider.php
@@ -8,7 +8,7 @@ use Exception;
 use OCA\OpenAi\AppInfo\Application;
 use OCA\OpenAi\Service\OpenAiAPIService;
 use OCA\OpenAi\Service\OpenAiSettingsService;
-use OCP\IConfig;
+use OCP\IAppConfig;
 use OCP\IL10N;
 use OCP\TaskProcessing\EShapeType;
 use OCP\TaskProcessing\ISynchronousProvider;
@@ -20,7 +20,7 @@ class TopicsProvider implements ISynchronousProvider {
 
 	public function __construct(
 		private OpenAiAPIService $openAiAPIService,
-		private IConfig $config,
+		private IAppConfig $appConfig,
 		private OpenAiSettingsService $openAiSettingsService,
 		private IL10N $l,
 		private ?string $userId,
@@ -74,8 +74,8 @@ class TopicsProvider implements ISynchronousProvider {
 
 	public function getOptionalInputShapeDefaults(): array {
 		$adminModel = $this->openAiAPIService->isUsingOpenAi()
-			? ($this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID)
-			: $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id');
+			? ($this->appConfig->getValueString(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID)
+			: $this->appConfig->getValueString(Application::APP_ID, 'default_completion_model_id');
 		return [
 			'max_tokens' => 1000,
 			'model' => $adminModel,
@@ -111,7 +111,7 @@ class TopicsProvider implements ISynchronousProvider {
 		if (isset($input['model']) && is_string($input['model'])) {
 			$model = $input['model'];
 		} else {
-			$model = $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID;
+			$model = $this->appConfig->getValueString(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID;
 		}
 
 		try {

--- a/lib/TaskProcessing/TranslateProvider.php
+++ b/lib/TaskProcessing/TranslateProvider.php
@@ -8,8 +8,8 @@ use Exception;
 use OCA\OpenAi\AppInfo\Application;
 use OCA\OpenAi\Service\OpenAiAPIService;
 use OCA\OpenAi\Service\OpenAiSettingsService;
+use OCP\IAppConfig;
 use OCP\ICacheFactory;
-use OCP\IConfig;
 use OCP\IL10N;
 use OCP\L10N\IFactory;
 use OCP\TaskProcessing\EShapeType;
@@ -24,7 +24,7 @@ class TranslateProvider implements ISynchronousProvider {
 
 	public function __construct(
 		private OpenAiAPIService $openAiAPIService,
-		private IConfig $config,
+		private IAppConfig $appConfig,
 		private OpenAiSettingsService $openAiSettingsService,
 		private IL10N $l,
 		private IFactory $l10nFactory,
@@ -92,8 +92,8 @@ class TranslateProvider implements ISynchronousProvider {
 
 	public function getOptionalInputShapeDefaults(): array {
 		$adminModel = $this->openAiAPIService->isUsingOpenAi()
-			? ($this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID)
-			: $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id');
+			? ($this->appConfig->getValueString(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID)
+			: $this->appConfig->getValueString(Application::APP_ID, 'default_completion_model_id');
 		return [
 			'max_tokens' => 1000,
 			'model' => $adminModel,
@@ -133,7 +133,7 @@ class TranslateProvider implements ISynchronousProvider {
 		if (isset($input['model']) && is_string($input['model'])) {
 			$model = $input['model'];
 		} else {
-			$model = $this->config->getAppValue(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID;
+			$model = $this->appConfig->getValueString(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID) ?: Application::DEFAULT_MODEL_ID;
 		}
 
 		if (!isset($input['input']) || !is_string($input['input'])) {

--- a/tests/unit/Providers/OpenAiProviderTest.php
+++ b/tests/unit/Providers/OpenAiProviderTest.php
@@ -21,7 +21,7 @@ use OCA\OpenAi\TaskProcessing\TextToTextProvider;
 use OCA\OpenAi\TaskProcessing\TranslateProvider;
 use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
-use OCP\IConfig;
+use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
@@ -68,7 +68,7 @@ class OpenAiProviderTest extends TestCase {
 		$this->openAiApiService = new OpenAiAPIService(
 			\OC::$server->get(\Psr\Log\LoggerInterface::class),
 			$this->createMock(\OCP\IL10N::class),
-			\OC::$server->get(IConfig::class),
+			\OC::$server->get(IAppConfig::class),
 			\OC::$server->get(QuotaUsageMapper::class),
 			$this->openAiSettingsService,
 			$clientService,
@@ -96,7 +96,7 @@ class OpenAiProviderTest extends TestCase {
 	public function testFreePromptProvider(): void {
 		$freePromptProvider = new TextToTextProvider(
 			$this->openAiApiService,
-			\OC::$server->get(IConfig::class),
+			\OC::$server->get(IAppConfig::class),
 			$this->openAiSettingsService,
 			$this->createMock(\OCP\IL10N::class),
 			self::TEST_USER1,
@@ -153,7 +153,7 @@ class OpenAiProviderTest extends TestCase {
 	public function testHeadlineProvider(): void {
 		$headlineProvider = new HeadlineProvider(
 			$this->openAiApiService,
-			\OC::$server->get(IConfig::class),
+			\OC::$server->get(IAppConfig::class),
 			$this->openAiSettingsService,
 			$this->createMock(\OCP\IL10N::class),
 			self::TEST_USER1,
@@ -210,7 +210,7 @@ class OpenAiProviderTest extends TestCase {
 	public function testSummaryProvider(): void {
 		$summaryProvider = new SummaryProvider(
 			$this->openAiApiService,
-			\OC::$server->get(IConfig::class),
+			\OC::$server->get(IAppConfig::class),
 			$this->openAiSettingsService,
 			$this->createMock(\OCP\IL10N::class),
 			self::TEST_USER1,
@@ -267,7 +267,7 @@ class OpenAiProviderTest extends TestCase {
 	public function testTranslationProvider(): void {
 		$translationProvider = new TranslateProvider(
 			$this->openAiApiService,
-			\OC::$server->get(IConfig::class),
+			\OC::$server->get(IAppConfig::class),
 			$this->openAiSettingsService,
 			$this->createMock(\OCP\IL10N::class),
 			\OC::$server->get(\OCP\L10N\IFactory::class),


### PR DESCRIPTION
So we can mark some values as sensitive and the encryption is handled by the core.

I left out the "old" providers because we can now get rid of them (as TaskProcessing providers can be used by the old APIs).

Also, I didn't use the getValueInt and setValueInt methods because I don't know how it behaves when the value stored in db is an empty string so I was afraid it would mess with the default values and too lazy to try and check how it behaves.