### PR TITLE
Fix: Use api key in image retrieval request

### DIFF
--- a/lib/Service/OpenAiAPIService.php
+++ b/lib/Service/OpenAiAPIService.php
@@ -593,12 +593,17 @@ class OpenAiAPIService {
 			],
 		];
 
-		$useBasicAuth = $this->openAiSettingsService->getUseBasicAuth();
-		if ($useBasicAuth && !$this->isUsingOpenAi()) {
-			$basicUser = $this->openAiSettingsService->getUserBasicUser($userId, true);
-			$basicPassword = $this->openAiSettingsService->getUserBasicPassword($userId, true);
-			if ($basicUser !== '' && $basicPassword !== '') {
-				$requestOptions['headers']['Authorization'] = 'Basic ' . base64_encode($basicUser . ':' . $basicPassword);
+		if (!$this->isUsingOpenAi()) {
+			$useBasicAuth = $this->openAiSettingsService->getUseBasicAuth();
+			if ($useBasicAuth) {
+				$basicUser = $this->openAiSettingsService->getUserBasicUser($userId, true);
+				$basicPassword = $this->openAiSettingsService->getUserBasicPassword($userId, true);
+				if ($basicUser !== '' && $basicPassword !== '') {
+					$requestOptions['headers']['Authorization'] = 'Basic ' . base64_encode($basicUser . ':' . $basicPassword);
+				}
+			} else {
+				$apiKey = $this->openAiSettingsService->getUserApiKey($userId, true);
+				$requestOptions['headers']['Authorization'] = 'Bearer ' . $apiKey;
 			}
 		}
 		return $requestOptions;


### PR DESCRIPTION
closes #138

If OpenAI is not used and the app is configured with an API key, use it when retrieving images.

This is a smaller alternative to #141. We can keep #141 (after removing the api-key-related changes) since it contains other improvements.