### PR TITLE
Cache the models for 30min in distributed cache

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -61,9 +61,8 @@ class Application extends App implements IBootstrap {
 
 	];
 
-	public const PROMPT_TYPE_IMAGE = 0;
-	public const PROMPT_TYPE_TEXT = 1;
-	public const MAX_PROMPT_PER_TYPE_PER_USER = 5;
+	public const MODELS_CACHE_KEY = 'models';
+	public const MODELS_CACHE_TTL = 60 * 30;
 
 	private IAppConfig $appConfig;
 

--- a/lib/Service/OpenAiSettingsService.php
+++ b/lib/Service/OpenAiSettingsService.php
@@ -421,6 +421,7 @@ class OpenAiSettingsService {
 			throw new Exception('Invalid service URL');
 		}
 		$this->appConfig->setValueString(Application::APP_ID, 'url', $serviceUrl);
+		$this->invalidateModelsCache();
 	}
 
 	/**

--- a/lib/Service/OpenAiSettingsService.php
+++ b/lib/Service/OpenAiSettingsService.php
@@ -26,6 +26,7 @@ namespace OCA\OpenAi\Service;
 use Exception;
 use OCA\OpenAi\AppInfo\Application;
 use OCP\IAppConfig;
+use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\PreConditionNotMetException;
 use OCP\Security\ICrypto;
@@ -64,8 +65,13 @@ class OpenAiSettingsService {
 		private IConfig $config,
 		private IAppConfig $appConfig,
 		private ICrypto $crypto,
+		private ICacheFactory $cacheFactory,
 	) {
+	}
 
+	public function invalidateModelsCache(): void {
+		$cache = $this->cacheFactory->createDistributed(Application::APP_ID);
+		$cache->remove(Application::MODELS_CACHE_KEY);
 	}
 
 	////////////////////////////////////////////
@@ -355,6 +361,7 @@ class OpenAiSettingsService {
 	public function setAdminApiKey(string $apiKey): void {
 		// No need to validate. As long as it's a string, we're happy campers
 		$this->appConfig->setValueString(Application::APP_ID, 'api_key', $apiKey, false, true);
+		$this->invalidateModelsCache();
 	}
 
 	/**
@@ -370,6 +377,7 @@ class OpenAiSettingsService {
 			$encryptedApiKey = $this->crypto->encrypt($apiKey);
 			$this->config->setUserValue($userId, Application::APP_ID, 'api_key', $encryptedApiKey);
 		}
+		$this->invalidateModelsCache();
 	}
 
 	/**
@@ -472,6 +480,7 @@ class OpenAiSettingsService {
 	 */
 	public function setAdminBasicUser(string $basicUser): void {
 		$this->appConfig->setValueString(Application::APP_ID, 'basic_user', $basicUser);
+		$this->invalidateModelsCache();
 	}
 
 	/**
@@ -480,6 +489,7 @@ class OpenAiSettingsService {
 	 */
 	public function setAdminBasicPassword(string $basicPassword): void {
 		$this->appConfig->setValueString(Application::APP_ID, 'basic_password', $basicPassword, false, true);
+		$this->invalidateModelsCache();
 	}
 
 	/**
@@ -490,6 +500,7 @@ class OpenAiSettingsService {
 	 */
 	public function setUserBasicUser(string $userId, string $basicUser): void {
 		$this->config->setUserValue($userId, Application::APP_ID, 'basic_user', $basicUser);
+		$this->invalidateModelsCache();
 	}
 
 	/**
@@ -501,6 +512,7 @@ class OpenAiSettingsService {
 	public function setUserBasicPassword(string $userId, string $basicPassword): void {
 		$encryptedBasicPassword = $basicPassword === '' ? '' : $this->crypto->encrypt($basicPassword);
 		$this->config->setUserValue($userId, Application::APP_ID, 'basic_password', $encryptedBasicPassword);
+		$this->invalidateModelsCache();
 	}
 
 	/**
@@ -509,6 +521,7 @@ class OpenAiSettingsService {
 	 */
 	public function setUseBasicAuth(bool $useBasicAuth): void {
 		$this->appConfig->setValueString(Application::APP_ID, 'use_basic_auth', $useBasicAuth ? '1' : '0');
+		$this->invalidateModelsCache();
 	}
 
 	/**

--- a/tests/unit/Providers/OpenAiProviderTest.php
+++ b/tests/unit/Providers/OpenAiProviderTest.php
@@ -22,6 +22,7 @@ use OCA\OpenAi\TaskProcessing\TranslateProvider;
 use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
 use OCP\IAppConfig;
+use OCP\ICacheFactory;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
@@ -69,6 +70,7 @@ class OpenAiProviderTest extends TestCase {
 			\OC::$server->get(\Psr\Log\LoggerInterface::class),
 			$this->createMock(\OCP\IL10N::class),
 			\OC::$server->get(IAppConfig::class),
+			\OC::$server->get(ICacheFactory::class),
 			\OC::$server->get(QuotaUsageMapper::class),
 			$this->openAiSettingsService,
 			$clientService,


### PR DESCRIPTION
Closes #146

I assume all user have access to the same models so there is a global cache. @kyteinsky Do you think it's likely that users have access to different models? I'm asking because they can set a different API key/credentials.