### PR TITLE
Fix: Use correct userId in most provider

### DIFF
--- a/lib/TaskProcessing/ContextWriteProvider.php
+++ b/lib/TaskProcessing/ContextWriteProvider.php
@@ -128,9 +128,9 @@ class ContextWriteProvider implements ISynchronousProvider {
 
 		try {
 			if ($this->openAiAPIService->isUsingOpenAi() || $this->openAiSettingsService->getChatEndpointEnabled()) {
-				$completion = $this->openAiAPIService->createChatCompletion($this->userId, $model, $prompt, null, null, 1, $maxTokens);
+				$completion = $this->openAiAPIService->createChatCompletion($userId, $model, $prompt, null, null, 1, $maxTokens);
 			} else {
-				$completion = $this->openAiAPIService->createCompletion($this->userId, $prompt, 1, $model, $maxTokens);
+				$completion = $this->openAiAPIService->createCompletion($userId, $prompt, 1, $model, $maxTokens);
 			}
 		} catch (Exception $e) {
 			throw new RuntimeException('OpenAI/LocalAI request failed: ' . $e->getMessage());

--- a/lib/TaskProcessing/HeadlineProvider.php
+++ b/lib/TaskProcessing/HeadlineProvider.php
@@ -116,9 +116,9 @@ class HeadlineProvider implements ISynchronousProvider {
 
 		try {
 			if ($this->openAiAPIService->isUsingOpenAi() || $this->openAiSettingsService->getChatEndpointEnabled()) {
-				$completion = $this->openAiAPIService->createChatCompletion($this->userId, $model, $prompt, null, null, 1, $maxTokens);
+				$completion = $this->openAiAPIService->createChatCompletion($userId, $model, $prompt, null, null, 1, $maxTokens);
 			} else {
-				$completion = $this->openAiAPIService->createCompletion($this->userId, $prompt, 1, $model, $maxTokens);
+				$completion = $this->openAiAPIService->createCompletion($userId, $prompt, 1, $model, $maxTokens);
 			}
 		} catch (Exception $e) {
 			throw new RuntimeException('OpenAI/LocalAI request failed: ' . $e->getMessage());

--- a/lib/TaskProcessing/ReformulateProvider.php
+++ b/lib/TaskProcessing/ReformulateProvider.php
@@ -116,9 +116,9 @@ class ReformulateProvider implements ISynchronousProvider {
 
 		try {
 			if ($this->openAiAPIService->isUsingOpenAi() || $this->openAiSettingsService->getChatEndpointEnabled()) {
-				$completion = $this->openAiAPIService->createChatCompletion($this->userId, $model, $prompt, null, null, 1, $maxTokens);
+				$completion = $this->openAiAPIService->createChatCompletion($userId, $model, $prompt, null, null, 1, $maxTokens);
 			} else {
-				$completion = $this->openAiAPIService->createCompletion($this->userId, $prompt, 1, $model, $maxTokens);
+				$completion = $this->openAiAPIService->createCompletion($userId, $prompt, 1, $model, $maxTokens);
 			}
 		} catch (Exception $e) {
 			throw new RuntimeException('OpenAI/LocalAI request failed: ' . $e->getMessage());

--- a/lib/TaskProcessing/SummaryProvider.php
+++ b/lib/TaskProcessing/SummaryProvider.php
@@ -116,9 +116,9 @@ class SummaryProvider implements ISynchronousProvider {
 
 		try {
 			if ($this->openAiAPIService->isUsingOpenAi() || $this->openAiSettingsService->getChatEndpointEnabled()) {
-				$completion = $this->openAiAPIService->createChatCompletion($this->userId, $model, $prompt, null, null, 1, $maxTokens);
+				$completion = $this->openAiAPIService->createChatCompletion($userId, $model, $prompt, null, null, 1, $maxTokens);
 			} else {
-				$completion = $this->openAiAPIService->createCompletion($this->userId, $prompt, 1, $model, $maxTokens);
+				$completion = $this->openAiAPIService->createCompletion($userId, $prompt, 1, $model, $maxTokens);
 			}
 		} catch (Exception $e) {
 			throw new RuntimeException('OpenAI/LocalAI request failed: ' . $e->getMessage());

--- a/lib/TaskProcessing/TextToTextChatProvider.php
+++ b/lib/TaskProcessing/TextToTextChatProvider.php
@@ -21,7 +21,6 @@ class TextToTextChatProvider implements ISynchronousProvider {
 		private OpenAiAPIService $openAiAPIService,
 		private IAppConfig $appConfig,
 		private IL10N $l,
-		private ?string $userId,
 	) {
 	}
 
@@ -104,7 +103,7 @@ class TextToTextChatProvider implements ISynchronousProvider {
 		}
 
 		try {
-			$completion = $this->openAiAPIService->createChatCompletion($this->userId, $adminModel, $userPrompt, $systemPrompt, $history, 1, $maxTokens);
+			$completion = $this->openAiAPIService->createChatCompletion($userId, $adminModel, $userPrompt, $systemPrompt, $history, 1, $maxTokens);
 		} catch (Exception $e) {
 			throw new RuntimeException('OpenAI/LocalAI request failed: ' . $e->getMessage());
 		}

--- a/lib/TaskProcessing/TextToTextProvider.php
+++ b/lib/TaskProcessing/TextToTextProvider.php
@@ -121,9 +121,9 @@ class TextToTextProvider implements ISynchronousProvider {
 
 		try {
 			if ($this->openAiAPIService->isUsingOpenAi() || $this->openAiSettingsService->getChatEndpointEnabled()) {
-				$completion = $this->openAiAPIService->createChatCompletion($this->userId, $model, $prompt, null, null, 1, $maxTokens);
+				$completion = $this->openAiAPIService->createChatCompletion($userId, $model, $prompt, null, null, 1, $maxTokens);
 			} else {
-				$completion = $this->openAiAPIService->createCompletion($this->userId, $prompt, 1, $model, $maxTokens);
+				$completion = $this->openAiAPIService->createCompletion($userId, $prompt, 1, $model, $maxTokens);
 			}
 		} catch (Exception $e) {
 			throw new RuntimeException('OpenAI/LocalAI request failed: ' . $e->getMessage());

--- a/lib/TaskProcessing/TopicsProvider.php
+++ b/lib/TaskProcessing/TopicsProvider.php
@@ -116,9 +116,9 @@ class TopicsProvider implements ISynchronousProvider {
 
 		try {
 			if ($this->openAiAPIService->isUsingOpenAi() || $this->openAiSettingsService->getChatEndpointEnabled()) {
-				$completion = $this->openAiAPIService->createChatCompletion($this->userId, $model, $prompt, null, null, 1, $maxTokens);
+				$completion = $this->openAiAPIService->createChatCompletion($userId, $model, $prompt, null, null, 1, $maxTokens);
 			} else {
-				$completion = $this->openAiAPIService->createCompletion($this->userId, $prompt, 1, $model, $maxTokens);
+				$completion = $this->openAiAPIService->createCompletion($userId, $prompt, 1, $model, $maxTokens);
 			}
 		} catch (Exception $e) {
 			throw new RuntimeException('OpenAI/LocalAI request failed: ' . $e->getMessage());

--- a/lib/TaskProcessing/TranslateProvider.php
+++ b/lib/TaskProcessing/TranslateProvider.php
@@ -167,9 +167,9 @@ class TranslateProvider implements ISynchronousProvider {
 			}
 
 			if ($this->openAiAPIService->isUsingOpenAi() || $this->openAiSettingsService->getChatEndpointEnabled()) {
-				$completion = $this->openAiAPIService->createChatCompletion($this->userId, $model, $prompt, null, null, 1, $maxTokens);
+				$completion = $this->openAiAPIService->createChatCompletion($userId, $model, $prompt, null, null, 1, $maxTokens);
 			} else {
-				$completion = $this->openAiAPIService->createCompletion($this->userId, $prompt, 1, $model, $maxTokens);
+				$completion = $this->openAiAPIService->createCompletion($userId, $prompt, 1, $model, $maxTokens);
 			}
 
 			if (count($completion) > 0) {


### PR DESCRIPTION
Since the provider's process method is called in a bg job, there is no userId injected in the constructors. That's why we have a userId param in the process method.

It was not a blocking problem because the quota check is successful when the userId is null. But still it was not checking the quota correctly.