### PR TITLE
fix: English headlines for English text with OpenAI

### DIFF
--- a/lib/TaskProcessing/HeadlineProvider.php
+++ b/lib/TaskProcessing/HeadlineProvider.php
@@ -101,7 +101,7 @@ class HeadlineProvider implements ISynchronousProvider {
 			throw new RuntimeException('Invalid prompt');
 		}
 		$prompt = $input['input'];
-		$prompt = 'Give me the headline of the following text in its original language. Output only the headline.' . "\n\n" . $prompt;
+		$prompt = 'Give me the headline of the following text in its original language. Do not output the language. Output only the headline without any quotes or additional punctuation.' . "\n\n" . $prompt;
 
 		$maxTokens = null;
 		if (isset($input['max_tokens']) && is_int($input['max_tokens'])) {

--- a/tests/unit/Providers/OpenAiProviderTest.php
+++ b/tests/unit/Providers/OpenAiProviderTest.php
@@ -190,7 +190,7 @@ class OpenAiProviderTest extends TestCase {
 		$url = self::OPENAI_API_BASE . 'chat/completions';
 
 		$options = ['timeout' => Application::OPENAI_DEFAULT_REQUEST_TIMEOUT, 'headers' => ['User-Agent' => Application::USER_AGENT, 'Authorization' => self::AUTHORIZATION_HEADER, 'Content-Type' => 'application/json']];
-		$message = 'Give me the headline of the following text in its original language. Output only the headline.' . "\n\n" . $prompt;
+		$message = 'Give me the headline of the following text in its original language. Do not output the language. Output only the headline without any quotes or additional punctuation.' . "\n\n" . $prompt;
 		$options['body'] = json_encode(['model' => Application::DEFAULT_COMPLETION_MODEL_ID, 'messages' => [['role' => 'user', 'content' => $message]], 'max_tokens' => Application::DEFAULT_MAX_NUM_OF_TOKENS, 'n' => $n, 'user' => self::TEST_USER1]);
 
 		$iResponse = $this->createMock(\OCP\Http\Client\IResponse::class);


### PR DESCRIPTION
resolves #161 

copied from https://github.com/nextcloud/llm2/blob/main/lib/headline.py#L30