### PR TITLE
Add ChatWithTools provider

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         ocp-version: [ 'dev-master' ]
-        php-version: [ '8.0', '8.1', '8.2', '8.3' ]
+        php-version: [ '8.1', '8.2', '8.3' ]
 
 
     name: Psalm check on PHP ${{ matrix.php-version }} and OCP ${{ matrix.ocp-version }}

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Nextcloud - OpenAI
  *

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
 			"composer/package-versions-deprecated": true
 		},
 		"platform": {
-			"php": "8.0"
+			"php": "8.1"
 		}
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9ca0605f9abffa47a821ed39f8316af8",
+    "content-hash": "d640b263721df3bd3a44de13fd090bec",
     "packages": [
         {
             "name": "bamarni/composer-bin-plugin",
@@ -71,16 +71,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "75fdb04d94e614ec08f1b7322b9fd64889655dab"
+                "reference": "e73188203e2b6c859ad865fc44d94530480c0af8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/75fdb04d94e614ec08f1b7322b9fd64889655dab",
-                "reference": "75fdb04d94e614ec08f1b7322b9fd64889655dab",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/e73188203e2b6c859ad865fc44d94530480c0af8",
+                "reference": "e73188203e2b6c859ad865fc44d94530480c0af8",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.0 || ~8.1 || ~8.2 || ~8.3",
+                "php": "~8.1 || ~8.2 || ~8.3",
                 "psr/clock": "^1.0",
                 "psr/container": "^2.0.2",
                 "psr/event-dispatcher": "^1.0",
@@ -101,14 +101,18 @@
                 {
                     "name": "Christoph Wurst",
                     "email": "christoph@winzerhof-wurst.at"
+                },
+                {
+                    "name": "Joas Schilling",
+                    "email": "coding@schilljs.com"
                 }
             ],
-            "description": "Composer package containing Nextcloud's public API (classes, interfaces)",
+            "description": "Composer package containing Nextcloud's public OCP API and the unstable NCU API",
             "support": {
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2024-11-18T10:21:20+00:00"
+            "time": "2024-12-10T00:49:44+00:00"
         },
         {
             "name": "psr/clock",
@@ -324,7 +328,7 @@
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "8.0"
+        "php": "8.1"
     },
     "plugin-api-version": "2.6.0"
 }

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Nextcloud - OpenAI
  *

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -99,6 +99,9 @@ class Application extends App implements IBootstrap {
 			$context->registerTaskProcessingProvider(ReformulateProvider::class);
 			$context->registerTaskProcessingTaskType(ChangeToneTaskType::class);
 			$context->registerTaskProcessingProvider(ChangeToneProvider::class);
+			if (class_exists('OCP\\TaskProcessing\\TaskTypes\\TextToTextChatWithTools')) {
+				$context->registerTaskProcessingProvider(\OCA\OpenAi\TaskProcessing\TextToTextChatWithToolsProvider::class);
+			}
 		}
 		if ($this->appConfig->getValueString(Application::APP_ID, 't2i_provider_enabled', '1') === '1') {
 			$context->registerTaskProcessingProvider(TextToImageProvider::class);

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Nextcloud - OpenAI
  *

--- a/lib/Controller/OpenAiAPIController.php
+++ b/lib/Controller/OpenAiAPIController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Nextcloud - OpenAI
  *

--- a/lib/OldProcessing/Translation/TranslationProvider.php
+++ b/lib/OldProcessing/Translation/TranslationProvider.php
@@ -91,6 +91,7 @@ class TranslationProvider implements ITranslationProvider, IDetectLanguageProvid
 		try {
 			if ($this->openAiAPIService->isUsingOpenAi() || $this->openAiSettingsService->getChatEndpointEnabled()) {
 				$completion = $this->openAiAPIService->createChatCompletion($this->userId, $adminModel, $prompt, null, null, 1, 100);
+				$completion = $completion['messages'];
 			} else {
 				$completion = $this->openAiAPIService->createCompletion($this->userId, $prompt, 1, $adminModel, 100);
 			}
@@ -137,6 +138,7 @@ class TranslationProvider implements ITranslationProvider, IDetectLanguageProvid
 
 			if ($this->openAiAPIService->isUsingOpenAi() || $this->openAiSettingsService->getChatEndpointEnabled()) {
 				$completion = $this->openAiAPIService->createChatCompletion($this->userId, $adminModel, $prompt, null, null, 1, PHP_INT_MAX);
+				$completion = $completion['messages'];
 			} else {
 				$completion = $this->openAiAPIService->createCompletion($this->userId, $prompt, 1, $adminModel, 4000);
 			}

--- a/lib/Service/OpenAiAPIService.php
+++ b/lib/Service/OpenAiAPIService.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Nextcloud - OpenAI
  *

--- a/lib/Service/OpenAiAPIService.php
+++ b/lib/Service/OpenAiAPIService.php
@@ -400,8 +400,8 @@ class OpenAiAPIService {
 							'type' => 'function',
 							'function' => $toolCall,
 						];
-						unset($formattedToolCall['function']['id']);
 						$formattedToolCall['function']['arguments'] = json_encode($toolCall['args']);
+						unset($formattedToolCall['function']['id']);
 						unset($formattedToolCall['function']['args']);
 						unset($formattedToolCall['function']['type']);
 						return $formattedToolCall;
@@ -414,9 +414,11 @@ class OpenAiAPIService {
 			$messages[] = ['role' => 'user', 'content' => $userPrompt];
 		}
 		if ($toolMessage !== null) {
-			$msg = json_decode($toolMessage, true);
-			$msg['role'] = 'tool';
-			$messages[] = $msg;
+			$msgs = json_decode($toolMessage, true);
+			foreach ($msgs as $msg) {
+				$msg['role'] = 'tool';
+				$messages[] = $msg;
+			}
 		}
 
 		$params = [

--- a/lib/Service/OpenAiAPIService.php
+++ b/lib/Service/OpenAiAPIService.php
@@ -403,7 +403,7 @@ class OpenAiAPIService {
 						unset($formattedToolCall['function']['id']);
 						$formattedToolCall['function']['arguments'] = json_encode($toolCall['args']);
 						unset($formattedToolCall['function']['args']);
-//						unset($formattedToolCall['function']['type']);
+						unset($formattedToolCall['function']['type']);
 						return $formattedToolCall;
 					}, $message['tool_calls']);
 				}

--- a/lib/Service/OpenAiAPIService.php
+++ b/lib/Service/OpenAiAPIService.php
@@ -456,9 +456,14 @@ class OpenAiAPIService {
 		];
 
 		foreach ($response['choices'] as $choice) {
-			if ($choice['finish_reason'] === 'tool_calls') {
+			// get tool calls only if this is the finish reason and it's defined and it's an array
+			if ($choice['finish_reason'] === 'tool_calls'
+				&& isset($choice['message']['tool_calls'])
+				&& is_array($choice['message']['tool_calls'])) {
 				$completions['tool_calls'][] = json_encode($choice['message']['tool_calls']);
-			} else {
+			}
+			// always try to get a message
+			if (isset($choice['message']['content']) && is_string($choice['message']['content'])) {
 				$completions['messages'][] = $choice['message']['content'];
 			}
 		}

--- a/lib/Service/OpenAiSettingsService.php
+++ b/lib/Service/OpenAiSettingsService.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Copyright (c) 2023, Sami Finnilä (sami.finnila@gmail.com)
  *

--- a/lib/TaskProcessing/ChangeToneProvider.php
+++ b/lib/TaskProcessing/ChangeToneProvider.php
@@ -129,6 +129,7 @@ class ChangeToneProvider implements ISynchronousProvider {
 		try {
 			if ($this->openAiAPIService->isUsingOpenAi() || $this->openAiSettingsService->getChatEndpointEnabled()) {
 				$completion = $this->openAiAPIService->createChatCompletion($userId, $model, $prompt, null, null, 1, $maxTokens);
+				$completion = $completion['messages'];
 			} else {
 				$completion = $this->openAiAPIService->createCompletion($userId, $prompt, 1, $model, $maxTokens);
 			}

--- a/lib/TaskProcessing/ContextWriteProvider.php
+++ b/lib/TaskProcessing/ContextWriteProvider.php
@@ -129,6 +129,7 @@ class ContextWriteProvider implements ISynchronousProvider {
 		try {
 			if ($this->openAiAPIService->isUsingOpenAi() || $this->openAiSettingsService->getChatEndpointEnabled()) {
 				$completion = $this->openAiAPIService->createChatCompletion($userId, $model, $prompt, null, null, 1, $maxTokens);
+				$completion = $completion['messages'];
 			} else {
 				$completion = $this->openAiAPIService->createCompletion($userId, $prompt, 1, $model, $maxTokens);
 			}

--- a/lib/TaskProcessing/HeadlineProvider.php
+++ b/lib/TaskProcessing/HeadlineProvider.php
@@ -117,6 +117,7 @@ class HeadlineProvider implements ISynchronousProvider {
 		try {
 			if ($this->openAiAPIService->isUsingOpenAi() || $this->openAiSettingsService->getChatEndpointEnabled()) {
 				$completion = $this->openAiAPIService->createChatCompletion($userId, $model, $prompt, null, null, 1, $maxTokens);
+				$completion = $completion['messages'];
 			} else {
 				$completion = $this->openAiAPIService->createCompletion($userId, $prompt, 1, $model, $maxTokens);
 			}

--- a/lib/TaskProcessing/ReformulateProvider.php
+++ b/lib/TaskProcessing/ReformulateProvider.php
@@ -117,6 +117,7 @@ class ReformulateProvider implements ISynchronousProvider {
 		try {
 			if ($this->openAiAPIService->isUsingOpenAi() || $this->openAiSettingsService->getChatEndpointEnabled()) {
 				$completion = $this->openAiAPIService->createChatCompletion($userId, $model, $prompt, null, null, 1, $maxTokens);
+				$completion = $completion['messages'];
 			} else {
 				$completion = $this->openAiAPIService->createCompletion($userId, $prompt, 1, $model, $maxTokens);
 			}

--- a/lib/TaskProcessing/TextToTextChatProvider.php
+++ b/lib/TaskProcessing/TextToTextChatProvider.php
@@ -104,6 +104,7 @@ class TextToTextChatProvider implements ISynchronousProvider {
 
 		try {
 			$completion = $this->openAiAPIService->createChatCompletion($userId, $adminModel, $userPrompt, $systemPrompt, $history, 1, $maxTokens);
+			$completion = $completion['messages'];
 		} catch (Exception $e) {
 			throw new RuntimeException('OpenAI/LocalAI request failed: ' . $e->getMessage());
 		}

--- a/lib/TaskProcessing/TextToTextChatWithToolsProvider.php
+++ b/lib/TaskProcessing/TextToTextChatWithToolsProvider.php
@@ -12,7 +12,6 @@ use OCP\IL10N;
 use OCP\TaskProcessing\EShapeType;
 use OCP\TaskProcessing\ISynchronousProvider;
 use OCP\TaskProcessing\ShapeDescriptor;
-use OCP\TaskProcessing\TaskTypes\TextToTextChat;
 use OCP\TaskProcessing\TaskTypes\TextToTextChatWithTools;
 use RuntimeException;
 

--- a/lib/TaskProcessing/TextToTextChatWithToolsProvider.php
+++ b/lib/TaskProcessing/TextToTextChatWithToolsProvider.php
@@ -107,11 +107,11 @@ class TextToTextChatWithToolsProvider implements ISynchronousProvider {
 			throw new RuntimeException('Invalid tools');
 		}
 		$tools = json_decode($input['tools']);
-		if (!is_array($tools) || !array_is_list($tools)) {
+		if (!is_array($tools) || !\array_is_list($tools)) {
 			throw new RuntimeException('Invalid JSON tools');
 		}
 
-		if (!isset($input['history']) || !is_array($input['history']) || !array_is_list($input['history'])) {
+		if (!isset($input['history']) || !is_array($input['history']) || !\array_is_list($input['history'])) {
 			throw new RuntimeException('Invalid history');
 		}
 		$history = $input['history'];

--- a/lib/TaskProcessing/TextToTextChatWithToolsProvider.php
+++ b/lib/TaskProcessing/TextToTextChatWithToolsProvider.php
@@ -86,6 +86,9 @@ class TextToTextChatWithToolsProvider implements ISynchronousProvider {
 			throw new RuntimeException('Invalid input');
 		}
 		$userPrompt = $input['input'];
+		if ($userPrompt === '') {
+			$userPrompt = null;
+		}
 
 		if (!isset($input['system_prompt']) || !is_string($input['system_prompt'])) {
 			throw new RuntimeException('Invalid system_prompt');
@@ -95,10 +98,10 @@ class TextToTextChatWithToolsProvider implements ISynchronousProvider {
 		if (!isset($input['tool_message']) || !is_string($input['tool_message'])) {
 			throw new RuntimeException('Invalid tool_message');
 		}
-		// TODO find a solution to allow passing no tool message
-		// OpenAI is rejecting the request if this param is set when there was no tool call done before
-		// and we are requiring this task input param
 		$toolMessage = $input['tool_message'];
+		if ($toolMessage === '') {
+			$toolMessage = null;
+		}
 
 		if (!isset($input['tools']) || !is_string($input['tools'])) {
 			throw new RuntimeException('Invalid tools');

--- a/lib/TaskProcessing/TextToTextChatWithToolsProvider.php
+++ b/lib/TaskProcessing/TextToTextChatWithToolsProvider.php
@@ -106,12 +106,12 @@ class TextToTextChatWithToolsProvider implements ISynchronousProvider {
 		if (!isset($input['tools']) || !is_string($input['tools'])) {
 			throw new RuntimeException('Invalid tools');
 		}
-		$tools = json_decode($input['tools'], true);
-		if (!is_array($tools)) {
+		$tools = json_decode($input['tools']);
+		if (!is_array($tools) || !array_is_list($tools)) {
 			throw new RuntimeException('Invalid JSON tools');
 		}
 
-		if (!isset($input['history']) || !is_array($input['history'])) {
+		if (!isset($input['history']) || !is_array($input['history']) || !array_is_list($input['history'])) {
 			throw new RuntimeException('Invalid history');
 		}
 		$history = $input['history'];

--- a/lib/TaskProcessing/TextToTextProvider.php
+++ b/lib/TaskProcessing/TextToTextProvider.php
@@ -122,6 +122,7 @@ class TextToTextProvider implements ISynchronousProvider {
 		try {
 			if ($this->openAiAPIService->isUsingOpenAi() || $this->openAiSettingsService->getChatEndpointEnabled()) {
 				$completion = $this->openAiAPIService->createChatCompletion($userId, $model, $prompt, null, null, 1, $maxTokens);
+				$completion = $completion['messages'];
 			} else {
 				$completion = $this->openAiAPIService->createCompletion($userId, $prompt, 1, $model, $maxTokens);
 			}

--- a/lib/TaskProcessing/TopicsProvider.php
+++ b/lib/TaskProcessing/TopicsProvider.php
@@ -117,6 +117,7 @@ class TopicsProvider implements ISynchronousProvider {
 		try {
 			if ($this->openAiAPIService->isUsingOpenAi() || $this->openAiSettingsService->getChatEndpointEnabled()) {
 				$completion = $this->openAiAPIService->createChatCompletion($userId, $model, $prompt, null, null, 1, $maxTokens);
+				$completion = $completion['messages'];
 			} else {
 				$completion = $this->openAiAPIService->createCompletion($userId, $prompt, 1, $model, $maxTokens);
 			}

--- a/lib/TaskProcessing/TranslateProvider.php
+++ b/lib/TaskProcessing/TranslateProvider.php
@@ -168,6 +168,7 @@ class TranslateProvider implements ISynchronousProvider {
 
 			if ($this->openAiAPIService->isUsingOpenAi() || $this->openAiSettingsService->getChatEndpointEnabled()) {
 				$completion = $this->openAiAPIService->createChatCompletion($userId, $model, $prompt, null, null, 1, $maxTokens);
+				$completion = $completion['messages'];
 			} else {
 				$completion = $this->openAiAPIService->createCompletion($userId, $prompt, 1, $model, $maxTokens);
 			}

--- a/vendor-bin/php-cs-fixer/composer.lock
+++ b/vendor-bin/php-cs-fixer/composer.lock
@@ -97,16 +97,16 @@
         },
         {
             "name": "php-cs-fixer/shim",
-            "version": "v3.64.0",
+            "version": "v3.65.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/shim.git",
-                "reference": "81ccfd24baf3a10810dab1152c403981a790b837"
+                "reference": "4983ec79b9dee926695ac324ea6e8d291935525d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/shim/zipball/81ccfd24baf3a10810dab1152c403981a790b837",
-                "reference": "81ccfd24baf3a10810dab1152c403981a790b837",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/shim/zipball/4983ec79b9dee926695ac324ea6e8d291935525d",
+                "reference": "4983ec79b9dee926695ac324ea6e8d291935525d",
                 "shasum": ""
             },
             "require": {
@@ -143,9 +143,9 @@
             "description": "A tool to automatically fix PHP code style",
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/shim/issues",
-                "source": "https://github.com/PHP-CS-Fixer/shim/tree/v3.64.0"
+                "source": "https://github.com/PHP-CS-Fixer/shim/tree/v3.65.0"
             },
-            "time": "2024-08-30T23:10:11+00:00"
+            "time": "2024-11-25T00:39:41+00:00"
         }
     ],
     "aliases": [],

--- a/vendor-bin/phpunit/composer.lock
+++ b/vendor-bin/phpunit/composer.lock
@@ -634,16 +634,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.21",
+            "version": "9.6.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "de6abf3b6f8dd955fac3caad3af7a9504e8c2ffa"
+                "reference": "f80235cb4d3caa59ae09be3adf1ded27521d1a9c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/de6abf3b6f8dd955fac3caad3af7a9504e8c2ffa",
-                "reference": "de6abf3b6f8dd955fac3caad3af7a9504e8c2ffa",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f80235cb4d3caa59ae09be3adf1ded27521d1a9c",
+                "reference": "f80235cb4d3caa59ae09be3adf1ded27521d1a9c",
                 "shasum": ""
             },
             "require": {
@@ -654,7 +654,7 @@
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.12.0",
+                "myclabs/deep-copy": "^1.12.1",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=7.3",
@@ -717,7 +717,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.21"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.22"
             },
             "funding": [
                 {
@@ -733,7 +733,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-19T10:50:18+00:00"
+            "time": "2024-12-05T13:48:26+00:00"
         },
         {
             "name": "sebastian/cli-parser",


### PR DESCRIPTION
This will be used by the Agency feature which uses the tooling capabilities of LLMs.

This provider can be tested in the assistant because it dynamically generates a form for the task type (we will hide this task type later).

One small issue: We enforce all the input params but we might wanna set the tool_message (The result of tool calls in the last interaction).
If we give a fake/useless value to the OpenAI API, the request fails because the tool_message does not come after a "tool call" message.
To be discussed.

To test this provider, just replace `$toolMessage = $input['tool_message'];` by `$toolMessage = null;` in the provider and pass a dummy tool_message value in the form.
As all input fields have to be defined, also add at least one message in the "chat history".
You can use that in the "tools" input:
``` json
[{
    "type":"function",
    "function":{
        "description":"get the weather in a city",
        "name":"get_city_weather"
    }
}]
```
So if you ask for the weather in the city, you should get a tool call as a response. If not, you should get a classic response.