### PR TITLE
Use max_completion_tokens instead of deprecated max_tokens

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -71,12 +71,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "e73188203e2b6c859ad865fc44d94530480c0af8"
+                "reference": "3d9b3b4d13b3a8ad441c1fd862dd7365e72840dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/e73188203e2b6c859ad865fc44d94530480c0af8",
-                "reference": "e73188203e2b6c859ad865fc44d94530480c0af8",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/3d9b3b4d13b3a8ad441c1fd862dd7365e72840dd",
+                "reference": "3d9b3b4d13b3a8ad441c1fd862dd7365e72840dd",
                 "shasum": ""
             },
             "require": {
@@ -112,7 +112,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2024-12-10T00:49:44+00:00"
+            "time": "2025-01-15T00:42:43+00:00"
         },
         {
             "name": "psr/clock",

--- a/lib/Service/OpenAiSettingsService.php
+++ b/lib/Service/OpenAiSettingsService.php
@@ -27,6 +27,7 @@ class OpenAiSettingsService {
 		'default_image_size' => 'string',
 		'chunk_size' => 'integer',
 		'max_tokens' => 'integer',
+		'use_max_completion_tokens_param' => 'boolean',
 		'llm_extra_params' => 'string',
 		'quota_period' => 'integer',
 		'quotas' => 'array',
@@ -268,6 +269,7 @@ class OpenAiSettingsService {
 			'default_image_size' => $this->getAdminDefaultImageSize(),
 			'chunk_size' => strval($this->getChunkSize()),
 			'max_tokens' => $this->getMaxTokens(),
+			'use_max_completion_tokens_param' => $this->getUseMaxCompletionTokensParam(),
 			'llm_extra_params' => $this->getLlmExtraParams(),
 			// Updated to get max tokens
 			'quota_period' => $this->getQuotaPeriod(),
@@ -299,6 +301,13 @@ class OpenAiSettingsService {
 			'is_custom_service' => $isCustomService,
 
 		];
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function getUseMaxCompletionTokensParam(): bool {
+		return $this->appConfig->getValueString(Application::APP_ID, 'use_max_completion_tokens_param', '1') === '1';
 	}
 
 	/**
@@ -610,6 +619,9 @@ class OpenAiSettingsService {
 		if (isset($adminConfig['quotas'])) {
 			$this->setQuotas($adminConfig['quotas']);
 		}
+		if (isset($adminConfig['use_max_completion_tokens_param'])) {
+			$this->setUseMaxCompletionParam($adminConfig['use_max_completion_tokens_param']);
+		}
 		if (isset($adminConfig['translation_provider_enabled'])) {
 			$this->setTranslationProviderEnabled($adminConfig['translation_provider_enabled']);
 		}
@@ -659,6 +671,14 @@ class OpenAiSettingsService {
 		if (isset($userConfig['basic_password'])) {
 			$this->setUserBasicPassword($userId, $userConfig['basic_password']);
 		}
+	}
+
+	/**
+	 * @param bool $enabled
+	 * @return void
+	 */
+	public function setUseMaxCompletionParam(bool $enabled): void {
+		$this->appConfig->setValueString(Application::APP_ID, 'use_max_completion_tokens_param', $enabled ? '1' : '0');
 	}
 
 	/**

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -445,6 +445,11 @@
 						</template>
 					</NcButton>
 				</div>
+				<NcCheckboxRadioSwitch
+					:checked="state.use_max_completion_tokens_param"
+					@update:checked="onCheckboxChanged($event, 'use_max_completion_tokens_param', false)">
+					{{ t('integration_openai', 'Use "{newParam}" parameter instead of the deprecated "{deprecatedParam}"', { newParam: 'max_completion_tokens', deprecatedParam: 'max_tokens' }) }}
+				</NcCheckboxRadioSwitch>
 			</div>
 			<div>
 				<h2>

--- a/tests/unit/Providers/OpenAiProviderTest.php
+++ b/tests/unit/Providers/OpenAiProviderTest.php
@@ -136,7 +136,13 @@ class OpenAiProviderTest extends TestCase {
 
 		$url = self::OPENAI_API_BASE . 'chat/completions';
 		$options = ['timeout' => Application::OPENAI_DEFAULT_REQUEST_TIMEOUT, 'headers' => ['User-Agent' => Application::USER_AGENT, 'Authorization' => self::AUTHORIZATION_HEADER, 'Content-Type' => 'application/json']];
-		$options['body'] = json_encode(['model' => Application::DEFAULT_COMPLETION_MODEL_ID, 'messages' => [['role' => 'user', 'content' => $prompt]], 'max_tokens' => Application::DEFAULT_MAX_NUM_OF_TOKENS, 'n' => $n, 'user' => self::TEST_USER1]);
+		$options['body'] = json_encode([
+			'model' => Application::DEFAULT_COMPLETION_MODEL_ID,
+			'messages' => [['role' => 'user', 'content' => $prompt]],
+			'n' => $n,
+			'max_completion_tokens' => Application::DEFAULT_MAX_NUM_OF_TOKENS,
+			'user' => self::TEST_USER1,
+		]);
 
 		$iResponse = $this->createMock(\OCP\Http\Client\IResponse::class);
 		$iResponse->method('getBody')->willReturn($response);
@@ -194,7 +200,13 @@ class OpenAiProviderTest extends TestCase {
 
 		$options = ['timeout' => Application::OPENAI_DEFAULT_REQUEST_TIMEOUT, 'headers' => ['User-Agent' => Application::USER_AGENT, 'Authorization' => self::AUTHORIZATION_HEADER, 'Content-Type' => 'application/json']];
 		$message = 'Give me the headline of the following text in its original language. Do not output the language. Output only the headline without any quotes or additional punctuation.' . "\n\n" . $prompt;
-		$options['body'] = json_encode(['model' => Application::DEFAULT_COMPLETION_MODEL_ID, 'messages' => [['role' => 'user', 'content' => $message]], 'max_tokens' => Application::DEFAULT_MAX_NUM_OF_TOKENS, 'n' => $n, 'user' => self::TEST_USER1]);
+		$options['body'] = json_encode([
+			'model' => Application::DEFAULT_COMPLETION_MODEL_ID,
+			'messages' => [['role' => 'user', 'content' => $message]],
+			'n' => $n,
+			'max_completion_tokens' => Application::DEFAULT_MAX_NUM_OF_TOKENS,
+			'user' => self::TEST_USER1,
+		]);
 
 		$iResponse = $this->createMock(\OCP\Http\Client\IResponse::class);
 		$iResponse->method('getBody')->willReturn($response);
@@ -252,7 +264,13 @@ class OpenAiProviderTest extends TestCase {
 
 		$options = ['timeout' => Application::OPENAI_DEFAULT_REQUEST_TIMEOUT, 'headers' => ['User-Agent' => Application::USER_AGENT, 'Authorization' => self::AUTHORIZATION_HEADER, 'Content-Type' => 'application/json']];
 		$message = "Reformulate the following text in a $toneInput tone in its original language. Output only the reformulation. Here is the text:" . "\n\n" . $textInput . "\n\n" . 'Do not mention the used language in your reformulation. Here is your reformulation in the same language:';
-		$options['body'] = json_encode(['model' => Application::DEFAULT_COMPLETION_MODEL_ID, 'messages' => [['role' => 'user', 'content' => $message]], 'max_tokens' => Application::DEFAULT_MAX_NUM_OF_TOKENS, 'n' => $n, 'user' => self::TEST_USER1]);
+		$options['body'] = json_encode([
+			'model' => Application::DEFAULT_COMPLETION_MODEL_ID,
+			'messages' => [['role' => 'user', 'content' => $message]],
+			'n' => $n,
+			'max_completion_tokens' => Application::DEFAULT_MAX_NUM_OF_TOKENS,
+			'user' => self::TEST_USER1,
+		]);
 
 		$iResponse = $this->createMock(\OCP\Http\Client\IResponse::class);
 		$iResponse->method('getBody')->willReturn($response);
@@ -310,7 +328,14 @@ class OpenAiProviderTest extends TestCase {
 
 		$options = ['timeout' => Application::OPENAI_DEFAULT_REQUEST_TIMEOUT, 'headers' => ['User-Agent' => Application::USER_AGENT, 'Authorization' => self::AUTHORIZATION_HEADER, 'Content-Type' => 'application/json']];
 		$systemPrompt = 'Summarize the following text in the same language as the text.';
-		$options['body'] = json_encode(['model' => Application::DEFAULT_COMPLETION_MODEL_ID, 'messages' => [['role' => 'system', 'content' => $systemPrompt], ['role' => 'user', 'content' => $prompt]], 'max_tokens' => Application::DEFAULT_MAX_NUM_OF_TOKENS, 'n' => $n, 'user' => self::TEST_USER1]);
+		$options['body'] = json_encode([
+			'model' => Application::DEFAULT_COMPLETION_MODEL_ID,
+			'messages' => [['role' => 'system', 'content' => $systemPrompt],
+				['role' => 'user', 'content' => $prompt]],
+			'n' => $n,
+			'max_completion_tokens' => Application::DEFAULT_MAX_NUM_OF_TOKENS,
+			'user' => self::TEST_USER1,
+		]);
 
 		$iResponse = $this->createMock(\OCP\Http\Client\IResponse::class);
 		$iResponse->method('getBody')->willReturn($response);
@@ -370,8 +395,8 @@ class OpenAiProviderTest extends TestCase {
 		$options['body'] = json_encode([
 			'model' => Application::DEFAULT_COMPLETION_MODEL_ID,
 			'messages' => [['role' => 'system', 'content' => $systemPrompt],['role' => 'user', 'content' => $prompt]],
-			'max_tokens' => Application::DEFAULT_MAX_NUM_OF_TOKENS,
 			'n' => $n,
+			'max_completion_tokens' => Application::DEFAULT_MAX_NUM_OF_TOKENS,
 			'user' => self::TEST_USER1,
 		]);
 
@@ -434,7 +459,13 @@ class OpenAiProviderTest extends TestCase {
 		$url = self::OPENAI_API_BASE . 'chat/completions';
 
 		$options = ['timeout' => Application::OPENAI_DEFAULT_REQUEST_TIMEOUT, 'headers' => ['User-Agent' => Application::USER_AGENT, 'Authorization' => self::AUTHORIZATION_HEADER, 'Content-Type' => 'application/json']];
-		$options['body'] = json_encode(['model' => Application::DEFAULT_COMPLETION_MODEL_ID, 'messages' => [['role' => 'user', 'content' => 'Translate from ' . $fromLang . ' to English (US): ' . $inputText]], 'max_tokens' => Application::DEFAULT_MAX_NUM_OF_TOKENS, 'n' => $n, 'user' => self::TEST_USER1]);
+		$options['body'] = json_encode([
+			'model' => Application::DEFAULT_COMPLETION_MODEL_ID,
+			'messages' => [['role' => 'user', 'content' => 'Translate from ' . $fromLang . ' to English (US): ' . $inputText]],
+			'n' => $n,
+			'max_completion_tokens' => Application::DEFAULT_MAX_NUM_OF_TOKENS,
+			'user' => self::TEST_USER1,
+		]);
 
 		$iResponse = $this->createMock(\OCP\Http\Client\IResponse::class);
 		$iResponse->method('getBody')->willReturn($response);

--- a/vendor-bin/php-cs-fixer/composer.lock
+++ b/vendor-bin/php-cs-fixer/composer.lock
@@ -97,16 +97,16 @@
         },
         {
             "name": "php-cs-fixer/shim",
-            "version": "v3.65.0",
+            "version": "v3.68.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/shim.git",
-                "reference": "4983ec79b9dee926695ac324ea6e8d291935525d"
+                "reference": "23acc692a99304559d4c94e9f299158ecd0ed7d1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/shim/zipball/4983ec79b9dee926695ac324ea6e8d291935525d",
-                "reference": "4983ec79b9dee926695ac324ea6e8d291935525d",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/shim/zipball/23acc692a99304559d4c94e9f299158ecd0ed7d1",
+                "reference": "23acc692a99304559d4c94e9f299158ecd0ed7d1",
                 "shasum": ""
             },
             "require": {
@@ -143,9 +143,9 @@
             "description": "A tool to automatically fix PHP code style",
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/shim/issues",
-                "source": "https://github.com/PHP-CS-Fixer/shim/tree/v3.65.0"
+                "source": "https://github.com/PHP-CS-Fixer/shim/tree/v3.68.0"
             },
-            "time": "2024-11-25T00:39:41+00:00"
+            "time": "2025-01-13T17:01:38+00:00"
         }
     ],
     "aliases": [],

--- a/vendor-bin/phpunit/composer.lock
+++ b/vendor-bin/phpunit/composer.lock
@@ -139,16 +139,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.3.1",
+            "version": "v5.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "8eea230464783aa9671db8eea6f8c6ac5285794b"
+                "reference": "447a020a1f875a434d62f2a401f53b82a396e494"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/8eea230464783aa9671db8eea6f8c6ac5285794b",
-                "reference": "8eea230464783aa9671db8eea6f8c6ac5285794b",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/447a020a1f875a434d62f2a401f53b82a396e494",
+                "reference": "447a020a1f875a434d62f2a401f53b82a396e494",
                 "shasum": ""
             },
             "require": {
@@ -191,9 +191,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.3.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.4.0"
             },
-            "time": "2024-10-08T18:51:32+00:00"
+            "time": "2024-12-30T11:07:19+00:00"
         },
         {
             "name": "phar-io/manifest",


### PR DESCRIPTION
* Use max_completion_tokens instead of deprecated max_tokens by default
* Add admin option to choose

When using OpenAI with o1 models, the deprecated max_tokens param is rejected and the request fails with
`Unsupported parameter: 'max_tokens' is not supported with this model.`
All good with the new `max_completion_tokens` param.
We keep the option to use the deprecated one as I assume many other services didn't adjust that yet.

refs https://github.com/nextcloud/assistant/issues/175