### PR TITLE
Add admin setting to toggle authentication in the image retrieval request

### DIFF
--- a/lib/Service/OpenAiAPIService.php
+++ b/lib/Service/OpenAiAPIService.php
@@ -662,7 +662,7 @@ class OpenAiAPIService {
 			],
 		];
 
-		if (!$this->isUsingOpenAi()) {
+		if ($this->openAiSettingsService->getIsImageRetrievalAuthenticated()) {
 			$useBasicAuth = $this->openAiSettingsService->getUseBasicAuth();
 			if ($useBasicAuth) {
 				$basicUser = $this->openAiSettingsService->getUserBasicUser($userId, true);

--- a/lib/Service/OpenAiSettingsService.php
+++ b/lib/Service/OpenAiSettingsService.php
@@ -25,6 +25,7 @@ class OpenAiSettingsService {
 		'default_stt_model_id' => 'string',
 		'default_image_model_id' => 'string',
 		'default_image_size' => 'string',
+		'image_request_auth' => 'boolean',
 		'chunk_size' => 'integer',
 		'max_tokens' => 'integer',
 		'use_max_completion_tokens_param' => 'boolean',
@@ -267,6 +268,7 @@ class OpenAiSettingsService {
 			'default_stt_model_id' => $this->getAdminDefaultSttModelId(),
 			'default_image_model_id' => $this->getAdminDefaultImageModelId(),
 			'default_image_size' => $this->getAdminDefaultImageSize(),
+			'image_request_auth' => $this->getIsImageRetrievalAuthenticated(),
 			'chunk_size' => strval($this->getChunkSize()),
 			'max_tokens' => $this->getMaxTokens(),
 			'use_max_completion_tokens_param' => $this->getUseMaxCompletionTokensParam(),
@@ -319,6 +321,16 @@ class OpenAiSettingsService {
 	 */
 	public function getTranslationProviderEnabled(): bool {
 		return $this->appConfig->getValueString(Application::APP_ID, 'translation_provider_enabled', '1') === '1';
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function getIsImageRetrievalAuthenticated(): bool {
+		$serviceUrl = $this->getServiceUrl();
+		$isUsingOpenAI = $serviceUrl === '' || $serviceUrl === Application::OPENAI_API_BASE_URL;
+		$default = $isUsingOpenAI ? '0' : '1';
+		return $this->appConfig->getValueString(Application::APP_ID, 'image_request_auth', $default) === '1';
 	}
 
 	/**
@@ -608,6 +620,9 @@ class OpenAiSettingsService {
 		if (isset($adminConfig['default_image_size'])) {
 			$this->setAdminDefaultImageSize($adminConfig['default_image_size']);
 		}
+		if (isset($adminConfig['image_request_auth'])) {
+			$this->setIsImageRetrievalAuthenticated($adminConfig['image_request_auth']);
+		}
 		if (isset($adminConfig['chunk_size'])) {
 			$this->setChunkSize(intval($adminConfig['chunk_size']));
 		}
@@ -691,6 +706,14 @@ class OpenAiSettingsService {
 	 */
 	public function setTranslationProviderEnabled(bool $enabled): void {
 		$this->appConfig->setValueString(Application::APP_ID, 'translation_provider_enabled', $enabled ? '1' : '0');
+	}
+
+	/**
+	 * @param bool $enabled
+	 * @return void
+	 */
+	public function setIsImageRetrievalAuthenticated(bool $enabled): void {
+		$this->appConfig->setValueString(Application::APP_ID, 'image_request_auth', $enabled ? '1' : '0');
 	}
 
 	/**

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -330,6 +330,11 @@
 						</template>
 					</NcButton>
 				</div>
+				<NcCheckboxRadioSwitch
+					:checked="state.image_request_auth"
+					@update:checked="onCheckboxChanged($event, 'image_request_auth', false)">
+					{{ t('integration_openai', 'Use authentication for image retrieval request') }}
+				</NcCheckboxRadioSwitch>
 			</div>
 			<div>
 				<h2>


### PR DESCRIPTION
closes #183 

In some cases, like when using a proxy like litellm (configured to use OpenAI), we need to authenticate to make the generation request (as usual) BUT once we get the result (that contains a list of URLs) the requests to download the images must not be authenticated (or it fails with `403 Server failed to authenticate the request...`).

Initially, for the image retrieval requests, we decided to not authenticate if OpenAI was the configured service and to authenticate for any other service.
This is now a bit more flexible:
* Default is the previous behaviour
* There is a "manual" option to override and choose whether those requests should be authenticated or not