### PR TITLE
Raise the default image size for compatibility

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -39,7 +39,7 @@ class Application extends App implements IBootstrap {
 	public const DEFAULT_COMPLETION_MODEL_ID = 'gpt-3.5-turbo';
 	public const DEFAULT_IMAGE_MODEL_ID = 'dall-e-2';
 	public const DEFAULT_TRANSCRIPTION_MODEL_ID = 'whisper-1';
-	public const DEFAULT_DEFAULT_IMAGE_SIZE = '512x512';
+	public const DEFAULT_DEFAULT_IMAGE_SIZE = '1024x1024';
 	public const MAX_GENERATION_IDLE_TIME = 60 * 60 * 24 * 10;
 	public const DEFAULT_CHUNK_SIZE = 10000;
 	public const MIN_CHUNK_SIZE = 500;

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -563,7 +563,7 @@ export default {
 			apiKeyUrl: 'https://platform.openai.com/account/api-keys',
 			quotaInfo: null,
 			llmExtraParamHint: t('integration_openai', 'JSON object. Check the API documentation to get the list of all available parameters. For example: {example}', { example: '{"stop":".","temperature":0.7}' }, null, { escape: false, sanitize: false }),
-			defaultImageSizeParamHint: t('integration_openai', 'Must be in 256x256 format (default is {default})', { default: '512x512' }),
+			defaultImageSizeParamHint: t('integration_openai', 'Must be in 256x256 format (default is {default})', { default: '1024x1024' }),
 			DEFAULT_MODEL_ITEM,
 			appSettingsAssistantUrl: generateUrl('/settings/apps/integration/assistant'),
 		}


### PR DESCRIPTION
Due to compatibility reasons, the default size should be set to 1024

- dall-e 2 can work with 512

but
- dall-e 3 can only work > 1024
https://platform.openai.com/docs/guides/images#size-and-quality-options
- IONOS can only work >1024
https://api.ionos.com/docs/inference-openai/v1/#tag/OpenAI-Compatible-Endpoints/operation/openaiCompatImagesGenerationsPost

so to make it compatible with the most, it should be adopted