### PR TITLE
3.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.7.1 – 2025-07-16
+
+### Fixed
+
+- Prefer using the old message format in the chat history: content is a string. Use the new format when there is audio @julien-nc [#237](https://github.com/nextcloud/integration_openai/pull/237)
+
+
 ## 3.7.0 – 2025-07-11
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -101,7 +101,7 @@ Negative:
 
 Learn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud.com/blog/nextcloud-ethical-ai-rating/).
 ]]>	</description>
-	<version>3.7.0</version>
+	<version>3.7.1</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>OpenAi</namespace>


### PR DESCRIPTION
## 3.7.1 – 2025-07-16

### Fixed

- Prefer using the old message format in the chat history: content is a string. Use the new format when there is audio @julien-nc [#237](https://github.com/nextcloud/integration_openai/pull/237)
