### PR TITLE
fix: admin settings style and quota fixes

### DIFF
--- a/lib/Service/OpenAiSettingsService.php
+++ b/lib/Service/OpenAiSettingsService.php
@@ -219,7 +219,7 @@ class OpenAiSettingsService {
 		// Make sure all quota types are set in the json encoded app value (in case new quota types are added in the future)
 		if (count($quotas) !== count(Application::DEFAULT_QUOTAS)) {
 			foreach (Application::DEFAULT_QUOTAS as $quotaType => $_) {
-				if (!isset($quotas[$quotaType])) {
+				if (!isset($quotas[$quotaType]) || !is_int($quotas[$quotaType]) || $quotas[$quotaType] < 0) {
 					$quotas[$quotaType] = Application::DEFAULT_QUOTAS[$quotaType];
 				}
 			}


### PR DESCRIPTION
Changes:
1. move max output tokens and use_max_completion_tokens_param to the text generation field below the max input tokens field so the settings are better placed
2. rename "Max new tokens" to "Max output tokens"
3. wrap checkboxes in `<div class="line">` for better spacing
4. add a info note card for quota usage and the meaning of the "0" value
5. sanitize quotas in the frontend and improved validation in the backend

![](https://github.com/user-attachments/assets/f2d54455-84df-4876-9e73-667e11def2fb)
![](https://github.com/user-attachments/assets/bb9969e4-a122-4961-8e5f-ba7b5fae4543)
