### PR TITLE
Empty argument gets encoded as [] instead of {}

### DIFF
--- a/lib/Service/OpenAiAPIService.php
+++ b/lib/Service/OpenAiAPIService.php
@@ -487,6 +487,9 @@ class OpenAiAPIService {
 							'function' => $toolCall,
 						];
 						$formattedToolCall['function']['arguments'] = json_encode($toolCall['args']);
+						if ($formattedToolCall['function']['arguments'] === '[]') {
+							$formattedToolCall['function']['arguments'] = '{}';
+						}
 						unset($formattedToolCall['function']['id']);
 						unset($formattedToolCall['function']['args']);
 						unset($formattedToolCall['function']['type']);


### PR DESCRIPTION
Gemini complains about a list being passed as the arguments instead of an object. It has an unintended side effect that every single empty object/array will be turned into an empty object when json encoded as a function argument.