### PR TITLE
feat: add monthly quota periods

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -5,18 +5,19 @@
 
 module.exports = {
 	globals: {
-		appVersion: true
+		appVersion: true,
 	},
 	parserOptions: {
-		requireConfigFile: false
+		requireConfigFile: false,
 	},
 	extends: [
-		'@nextcloud'
+		'@nextcloud',
 	],
 	rules: {
 		'jsdoc/require-jsdoc': 'off',
 		'jsdoc/tag-lines': 'off',
 		'vue/first-attribute-linebreak': 'off',
-		'import/extensions': 'off'
-	}
+		'import/extensions': 'off',
+		'vue/no-v-model-argument': 'off',
+	},
 }

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -55,6 +55,7 @@ class Application extends App implements IBootstrap {
 	public const MIN_CHUNK_SIZE = 500;
 	public const DEFAULT_MAX_NUM_OF_TOKENS = 1000;
 	public const DEFAULT_QUOTA_PERIOD = 30;
+	public const DEFAULT_QUOTA_CONFIG = ['length' => self::DEFAULT_QUOTA_PERIOD, 'unit' => 'day'];
 
 	public const DEFAULT_OPENAI_TEXT_GENERATION_TIME = 10; // seconds
 	public const DEFAULT_LOCALAI_TEXT_GENERATION_TIME = 60; // seconds

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -55,7 +55,7 @@ class Application extends App implements IBootstrap {
 	public const MIN_CHUNK_SIZE = 500;
 	public const DEFAULT_MAX_NUM_OF_TOKENS = 1000;
 	public const DEFAULT_QUOTA_PERIOD = 30;
-	public const DEFAULT_QUOTA_CONFIG = ['length' => self::DEFAULT_QUOTA_PERIOD, 'unit' => 'day'];
+	public const DEFAULT_QUOTA_CONFIG = ['length' => self::DEFAULT_QUOTA_PERIOD, 'unit' => 'day', 'day' => 1];
 
 	public const DEFAULT_OPENAI_TEXT_GENERATION_TIME = 10; // seconds
 	public const DEFAULT_LOCALAI_TEXT_GENERATION_TIME = 60; // seconds

--- a/lib/Db/QuotaUsageMapper.php
+++ b/lib/Db/QuotaUsageMapper.php
@@ -70,18 +70,15 @@ class QuotaUsageMapper extends QBMapper {
 
 	/**
 	 * @param int $type Type of the quota
-	 * @param int $timePeriod Time period in days
+	 * @param int $periodStart Start time of quota
 	 * @return int
 	 * @throws DoesNotExistException
 	 * @throws Exception
 	 * @throws MultipleObjectsReturnedException
 	 * @throws \RuntimeException
 	 */
-	public function getQuotaUnitsInTimePeriod(int $type, int $timePeriod): int {
+	public function getQuotaUnitsInTimePeriod(int $type, int $periodStart): int {
 		$qb = $this->db->getQueryBuilder();
-
-		// Get a timestamp of the beginning of the time period
-		$periodStart = (new DateTime())->sub(new DateInterval('P' . $timePeriod . 'D'))->getTimestamp();
 
 		// Get the sum of the units used in the time period
 		$qb->select($qb->createFunction('SUM(units)'))
@@ -103,18 +100,15 @@ class QuotaUsageMapper extends QBMapper {
 	/**
 	 * @param string $userId
 	 * @param int $type Type of the quota
-	 * @param int $timePeriod Time period in days
+	 * @param int $periodStart Start time of quota
 	 * @return int
 	 * @throws DoesNotExistException
 	 * @throws Exception
 	 * @throws MultipleObjectsReturnedException
 	 * @throws \RuntimeException
 	 */
-	public function getQuotaUnitsOfUserInTimePeriod(string $userId, int $type, int $timePeriod): int {
+	public function getQuotaUnitsOfUserInTimePeriod(string $userId, int $type, int $periodStart): int {
 		$qb = $this->db->getQueryBuilder();
-
-		// Get a timestamp of the beginning of the time period
-		$periodStart = (new DateTime())->sub(new DateInterval('P' . $timePeriod . 'D'))->getTimestamp();
 
 		// Get the sum of the units used in the time period
 		$qb->select($qb->createFunction('SUM(units)'))

--- a/lib/Service/OpenAiSettingsService.php
+++ b/lib/Service/OpenAiSettingsService.php
@@ -65,6 +65,8 @@ class OpenAiSettingsService {
 	}
 
 	/**
+	 * Gets the timestamp of the beginning of the quota period
+	 *
 	 * @return int
 	 * @throws Exception
 	 */
@@ -93,6 +95,9 @@ class OpenAiSettingsService {
 	}
 
 	/**
+	 * Gets the timestamp of the end of the quota period
+	 * if the period is floating, then this will be the current time
+	 *
 	 * @return int
 	 * @throws Exception
 	 */
@@ -262,11 +267,14 @@ class OpenAiSettingsService {
 			$this->appConfig->getValueString(Application::APP_ID, 'quota_period', json_encode(Application::DEFAULT_QUOTA_CONFIG)),
 			true
 		) ?: Application::DEFAULT_QUOTA_CONFIG;
+		// Migrate from old quota period to new one
 		if (is_int($value)) {
-			return [
-				'length' => $value,
-				'unit' => 'day',
-			];
+			$value = ['length' => $value];
+		}
+		foreach (Application::DEFAULT_QUOTA_CONFIG as $key => $defaultValue) {
+			if (!isset($value[$key])) {
+				$value[$key] = $defaultValue;
+			}
 		}
 		return $value;
 	}

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -500,19 +500,9 @@
 				</h2>
 				<div class="line">
 					<!--Time period in days for the token usage-->
-					<NcInputField
-						id="openai-api-quota-period"
-						v-model="state.quota_period"
-						class="input"
-						type="number"
-						:label="t('integration_openai', 'Quota enforcement time period (days)')"
-						:show-trailing-button="!!state.quota_period"
-						@update:model-value="onInput()"
-						@trailing-button-click="state.quota_period = '' ; onInput()">
-						<template #trailing-button-icon>
-							<CloseIcon :size="20" />
-						</template>
-					</NcInputField>
+					<QuotaPeriodPicker
+						v-model:value="state.quota_period"
+						@update:value="onInput()" />
 				</div>
 				<h2>
 					{{ t('integration_openai', 'Usage quotas per time period') }}
@@ -619,6 +609,7 @@ import { loadState } from '@nextcloud/initial-state'
 import { confirmPassword } from '@nextcloud/password-confirmation'
 import { generateUrl } from '@nextcloud/router'
 import debounce from 'debounce'
+import QuotaPeriodPicker from './QuotaPeriodPicker.vue'
 
 const DEFAULT_MODEL_ITEM = { id: 'Default' }
 
@@ -626,6 +617,7 @@ export default {
 	name: 'AdminSettings',
 
 	components: {
+		QuotaPeriodPicker,
 		OpenAiIcon,
 		KeyOutlineIcon,
 		CloseIcon,
@@ -871,7 +863,7 @@ export default {
 				max_tokens: parseInt(this.state.max_tokens),
 				llm_extra_params: this.state.llm_extra_params,
 				default_image_size: this.state.default_image_size,
-				quota_period: parseInt(this.state.quota_period),
+				quota_period: this.state.quota_period,
 				quotas: this.state.quotas,
 				tts_voices: this.state.tts_voices,
 				default_tts_voice: this.state.default_tts_voice,

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -168,12 +168,12 @@ export default {
 	computed: {
 		quotaRangeText() {
 			return this.quotaInfo?.period?.unit === 'month'
-				? t('integration_openai', 'This quota period is from {startDate} to {endDate}.', {
+				? t('integration_openai', 'This quota period is from {startDate} to {endDate}', {
 					startDate: formatRelativeTime(this.quotaInfo.start * 1000),
 					endDate: formatRelativeTime(this.quotaInfo.end * 1000),
 				})
-				: n('integration_openai', 'The quota is kept over a floating period of the last %n day.',
-					'The quota is kept over a floating period of the last %n days.', this.quotaInfo.period.length)
+				: n('integration_openai', 'The quota is kept over a floating period of the last %n day',
+					'The quota is kept over a floating period of the last %n days', this.quotaInfo.period.length)
 		},
 	},
 

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -109,6 +109,9 @@
 						</tr>
 					</tbody>
 				</table>
+				<NcNoteCard type="success">
+					{{ quotaRangeText }}
+				</NcNoteCard>
 			</div>
 			<div v-if="!state.is_custom_service">
 				<NcNoteCard type="info">
@@ -135,6 +138,7 @@ import { loadState } from '@nextcloud/initial-state'
 import { confirmPassword } from '@nextcloud/password-confirmation'
 import { generateUrl } from '@nextcloud/router'
 import debounce from 'debounce'
+import { formatRelativeTime } from '@nextcloud/l10n'
 
 export default {
 	name: 'PersonalSettings',
@@ -162,10 +166,18 @@ export default {
 	},
 
 	computed: {
+		quotaRangeText() {
+			return this.quotaInfo?.period?.unit === 'month'
+				? t('integration_openai', 'This quota period is from {startDate} to {endDate}.', {
+					startDate: formatRelativeTime(this.quotaInfo.start * 1000),
+					endDate: formatRelativeTime(this.quotaInfo.end * 1000),
+				})
+				: n('integration_openai', 'The quota is kept over a floating period of the last %n day.',
+					'The quota is kept over a floating period of the last %n days.', this.quotaInfo.period.length)
+		},
 	},
 
-	watch: {
-	},
+	watch: {},
 
 	mounted() {
 		this.loadQuotaInfo()

--- a/src/components/QuotaPeriodPicker.vue
+++ b/src/components/QuotaPeriodPicker.vue
@@ -1,0 +1,123 @@
+<!--
+  - SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<template>
+	<div class="container">
+		<NcNoteCard type="info">
+			{{
+				t('integration_openai', 'Daily quotas are floating quotas while monthly reset on a certain day of the month.')
+			}}
+		</NcNoteCard>
+		<div class="line">
+			<span class="text-cell">
+				{{
+					floating ? t('integration_openai', 'Quota enforcement time ') : t('integration_openai', 'Reset quota every')
+				}}
+			</span>
+			<NcInputField
+				id="quota"
+				:model-value="value.length"
+				class="input"
+				type="number"
+				@update:model-value="update('length', $event)" />
+			<NcSelect
+				:model-value="unitOptionName"
+				:options="unitOptions"
+				@update:model-value="update('unit', $event.id)" />
+		</div>
+		<div v-if="value.unit==='month'" class="line">
+			<span class="text-cell">
+				{{ t('integration_openai', 'On day') }}
+			</span>
+			<NcInputField
+				id="quota"
+				:model-value="value?.day ?? 1"
+				class="input"
+				type="number"
+				@update:model-value="update('day', $event)" />
+		</div>
+		<NcNoteCard type="success">
+			{{ resetText }}
+		</NcNoteCard>
+	</div>
+</template>
+
+<script>
+
+import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
+import NcInputField from '@nextcloud/vue/components/NcInputField'
+import NcSelect from '@nextcloud/vue/components/NcSelect'
+
+export default {
+	name: 'QuotaPeriodPicker',
+
+	components: {
+		NcNoteCard,
+		NcInputField,
+		NcSelect,
+	},
+
+	props: {
+		value: {
+			type: Object,
+			required: true,
+		},
+	},
+
+	emits: ['update:value'],
+
+	data() {
+		return {
+			unitOptions: [
+				{ id: 'day', label: t('integration_openai', 'Days') },
+				{ id: 'month', label: t('integration_openai', 'Months') },
+			],
+		}
+	},
+
+	computed: {
+		floating() {
+			return this.value.unit === 'day'
+		},
+		unitOptionName() {
+			return this.unitOptions.find(option => option.id === this.value.unit)?.label ?? ''
+		},
+		resetText() {
+			return this.floating
+				? n('integration_openai', 'Quota will be enforced based on last %n day of usage.', 'Quota will be enforced based on last %n days of usage.', this.value.length)
+				: n('integration_openai', 'Quota will reset all users every month on day {day}.', 'Quota will reset for all users every %n months on day {day}.', this.value.length, { day: this.value.day })
+		},
+	},
+
+	watch: {},
+
+	mounted() {
+	},
+
+	methods: {
+		update(key, value) {
+			console.debug('update', key, value)
+			if (value || value === false || value === 0) {
+				this.$emit('update:value', { ...this.value, [key]: value })
+			}
+		},
+	},
+}
+</script>
+
+<style scoped lang="scss">
+.line {
+	display: flex;
+	align-items: center;
+	gap: 5px;
+}
+
+.container {
+	width: 100%;
+}
+
+.input {
+	width: 100px;
+}
+</style>

--- a/src/components/QuotaPeriodPicker.vue
+++ b/src/components/QuotaPeriodPicker.vue
@@ -6,7 +6,7 @@
 	<div class="container">
 		<NcNoteCard type="info">
 			{{
-				t('integration_openai', 'Daily quotas are floating quotas while monthly reset on a certain day of the month.')
+				t('integration_openai', 'Daily quotas are floating quotas while monthly reset on a certain day of the month')
 			}}
 		</NcNoteCard>
 		<div class="line">
@@ -85,8 +85,8 @@ export default {
 		},
 		resetText() {
 			return this.floating
-				? n('integration_openai', 'Quota will be enforced based on last %n day of usage.', 'Quota will be enforced based on last %n days of usage.', this.value.length)
-				: n('integration_openai', 'Quota will reset all users every month on day {day}.', 'Quota will reset for all users every %n months on day {day}.', this.value.length, { day: this.value.day })
+				? n('integration_openai', 'Quota will be enforced based on last %n day of usage', 'Quota will be enforced based on last %n days of usage', this.value.length)
+				: n('integration_openai', 'Quota will reset all users every month on day {day}', 'Quota will reset for all users every %n months on day {day}', this.value.length, { day: this.value.day })
 		},
 	},
 


### PR DESCRIPTION
This does the minimum to fix this adding a monthly option for period that resets every month or exact multiple of months. This could also be used for yearly as long as a start date of January is ok. The date range was originally planned to be put into the admin settings, but I think it looks better in personal settings.
Resolves part of: #250
## Admin Settings
<img width="1469" height="537" alt="image" src="https://github.com/user-attachments/assets/87e754ee-233a-40b4-87e4-d0520e6fae8a" />
<img width="1432" height="260" alt="image" src="https://github.com/user-attachments/assets/44a549b8-214e-4f25-b2a3-c53e5e671fa2" />

## Personal Settings
<img width="1457" height="458" alt="image" src="https://github.com/user-attachments/assets/141ad552-7b57-44fb-b585-3ff64d27957f" />
<img width="1433" height="252" alt="image" src="https://github.com/user-attachments/assets/f2cf3e77-bf83-4d3a-96e8-9b47c7d54249" />
