### PR TITLE
Feat: quota report download

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -20,5 +20,6 @@ return [
 		['name' => 'quotaRule#addRule', 'url' => '/quota/rule', 'verb' => 'POST'],
 		['name' => 'quotaRule#updateRule', 'url' => '/quota/rule', 'verb' => 'PUT'],
 		['name' => 'quotaRule#deleteRule', 'url' => '/quota/rule', 'verb' => 'DELETE'],
+		['name' => 'quotaRule#getQuotaUsage', 'url' => '/quota/download-usage', 'verb' => 'GET'],
 	],
 ];

--- a/lib/Cron/CleanupQuotaDb.php
+++ b/lib/Cron/CleanupQuotaDb.php
@@ -30,14 +30,15 @@ class CleanupQuotaDb extends TimedJob {
 	protected function run($argument) {
 		$this->logger->debug('Run cleanup job for OpenAI quota db');
 		$quota = $this->openAiSettingsService->getQuotaPeriod();
-		$days = $quota['length'];
+		$quotaDays = $quota['length'];
 		if ($quota['unit'] == 'month') {
-			$days *= 30;
+			$quotaDays *= 30;
 		}
+		$days = $this->openAiSettingsService->getUsageStorageTime();
 		$this->quotaUsageMapper->cleanupQuotaUsages(
 			// The mimimum period is limited to DEFAULT_QUOTA_PERIOD to not lose
 			// the stored quota usage data below this limit.
-			max($days, Application::DEFAULT_QUOTA_PERIOD)
+			max($quotaDays, $days, Application::DEFAULT_QUOTA_PERIOD)
 		);
 
 	}

--- a/lib/Service/OpenAiSettingsService.php
+++ b/lib/Service/OpenAiSettingsService.php
@@ -37,6 +37,7 @@ class OpenAiSettingsService {
 		'llm_extra_params' => 'string',
 		'quota_period' => 'array',
 		'quotas' => 'array',
+		'usage_storage_time' => 'integer',
 		'translation_provider_enabled' => 'boolean',
 		'llm_provider_enabled' => 'boolean',
 		't2i_provider_enabled' => 'boolean',
@@ -310,6 +311,10 @@ class OpenAiSettingsService {
 		return $quotas;
 	}
 
+	public function getUsageStorageTime() : int {
+		return $this->appConfig->getValueInt(Application::APP_ID, 'usage_storage_time', Application::DEFAULT_QUOTA_PERIOD, lazy: true);
+	}
+
 	/**
 	 * @return boolean
 	 */
@@ -397,6 +402,7 @@ class OpenAiSettingsService {
 			// Updated to get quota period
 			'quotas' => $this->getQuotas(),
 			// Get quotas from the config value and return it
+			'usage_storage_time' => $this->getUsageStorageTime(),
 			'translation_provider_enabled' => $this->getTranslationProviderEnabled(),
 			'llm_provider_enabled' => $this->getLlmProviderEnabled(),
 			't2i_provider_enabled' => $this->getT2iProviderEnabled(),
@@ -522,6 +528,15 @@ class OpenAiSettingsService {
 		$this->appConfig->setValueString(Application::APP_ID, 'quotas', json_encode($quotas, JSON_THROW_ON_ERROR), lazy: true);
 		$cache = $this->cacheFactory->createDistributed(Application::APP_ID);
 		$cache->clear(Application::QUOTA_RULES_CACHE_PREFIX);
+	}
+
+	/**
+	 * @param int $usageStorageTime
+	 * @return void
+	 */
+	public function setUsageStorageTime(int $usageStorageTime): void {
+		$usageStorageTime = max(1, $usageStorageTime);
+		$this->appConfig->setValueInt(Application::APP_ID, 'usage_storage_time', $usageStorageTime, lazy: true);
 	}
 
 	/**
@@ -832,6 +847,9 @@ class OpenAiSettingsService {
 		}
 		if (isset($adminConfig['quotas'])) {
 			$this->setQuotas($adminConfig['quotas']);
+		}
+		if (isset($adminConfig['usage_storage_time'])) {
+			$this->setUsageStorageTime(intval($adminConfig['usage_storage_time']));
 		}
 		if (isset($adminConfig['use_max_completion_tokens_param'])) {
 			$this->setUseMaxCompletionParam($adminConfig['use_max_completion_tokens_param']);

--- a/lib/Service/OpenAiSettingsService.php
+++ b/lib/Service/OpenAiSettingsService.php
@@ -119,7 +119,9 @@ class OpenAiSettingsService {
 				$startDate = new DateTime('2000-01-' . $quotaPeriod['day']);
 				$months = $startDate->diff($periodEnd)->m + $startDate->diff($periodEnd)->y * 12;
 				$remainder = $months % $quotaPeriod['length'];
-				$periodEnd = $periodEnd->add(new DateInterval('P' . $quotaPeriod['length'] - $remainder . 'M'));
+				if ($remainder != 0) {
+					$periodEnd = $periodEnd->add(new DateInterval('P' . $quotaPeriod['length'] - $remainder . 'M'));
+				}
 			}
 		}
 		return $periodEnd->getTimestamp();

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -33,6 +33,8 @@ class Admin implements ISettings {
 		$adminConfig['basic_password'] = $adminConfig['basic_password'] === '' ? '' : 'dummyPassword';
 		$isAssistantEnabled = $this->appManager->isEnabledForUser('assistant');
 		$adminConfig['assistant_enabled'] = $isAssistantEnabled;
+		$adminConfig['quota_start_date'] = $this->openAiSettingsService->getQuotaStart();
+		$adminConfig['quota_end_date'] = $this->openAiSettingsService->getQuotaEnd();
 		$this->initialStateService->provideInitialState('admin-config', $adminConfig);
 		$rules = $this->quotaRuleService->getRules();
 		$this->initialStateService->provideInitialState('rules', $rules);

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -546,6 +546,15 @@
 						</tr>
 					</tbody>
 				</table>
+				<div class="line">
+					<NcInputField
+						id="openai-api-usage-storage-time"
+						v-model="state.usage_storage_time"
+						class="input"
+						type="number"
+						:label="t('integration_openai', 'Time period (days) for usage storage')"
+						@update:model-value="onInput()" />
+				</div>
 				<div class="line-gap">
 					<NcDateTimePickerNative
 						v-model="quota_usage.start_date"
@@ -907,6 +916,7 @@ export default {
 				quotas: this.state.quotas,
 				tts_voices: this.state.tts_voices,
 				default_tts_voice: this.state.default_tts_voice,
+				usage_storage_time: this.state.usage_storage_time,
 			}
 			await this.saveOptions(values, false)
 		}, 2000),

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -546,6 +546,21 @@
 						</tr>
 					</tbody>
 				</table>
+				<div class="line-gap">
+					<NcDateTimePickerNative
+						v-model="quota_usage.start_date"
+						:label="t('integration_openai', 'Start date')" />
+					<NcDateTimePickerNative
+						v-model="quota_usage.end_date"
+						:label="t('integration_openai', 'End date')" />
+					<NcSelect
+						v-model="quota_usage.quota_type"
+						:options="quotaTypes"
+						:input-label="t('integration_openai', 'Quota type')" />
+					<NcButton :href="downloadQuotaUsageUrl" class="download-button">
+						{{ t('integration_openai', 'Download quota usage') }}
+					</NcButton>
+				</div>
 				<h2>{{ t('integration_openai', 'Quota Rules') }}</h2>
 				<QuotaRules :quota-info="quotaInfo" />
 			</div>
@@ -605,6 +620,7 @@ import NcInputField from '@nextcloud/vue/components/NcInputField'
 import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
 import NcSelect from '@nextcloud/vue/components/NcSelect'
 import NcTextField from '@nextcloud/vue/components/NcTextField'
+import NcDateTimePickerNative from '@nextcloud/vue/components/NcDateTimePickerNative'
 
 import axios from '@nextcloud/axios'
 import { showError, showSuccess } from '@nextcloud/dialogs'
@@ -634,12 +650,14 @@ export default {
 		NcTextField,
 		NcInputField,
 		NcNoteCard,
+		NcDateTimePickerNative,
 		QuotaRules,
 	},
 
 	data() {
+		const state = loadState('integration_openai', 'admin-config')
 		return {
-			state: loadState('integration_openai', 'admin-config'),
+			state,
 			// to prevent some browsers to fill fields with remembered passwords
 			readonly: true,
 			models: null,
@@ -655,10 +673,25 @@ export default {
 			defaultImageSizeParamHint: t('integration_openai', 'Must be in 256x256 format (default is {default})', { default: '1024x1024' }),
 			DEFAULT_MODEL_ITEM,
 			appSettingsAssistantUrl: generateUrl('/settings/apps/integration/assistant'),
+			quota_usage: {
+				quota_type: { id: 0, label: '' },
+				start_date: new Date(state.quota_start_date * 1000),
+				end_date: new Date(state.quota_end_date * 1000),
+			},
 		}
 	},
 
 	computed: {
+		quotaTypes() {
+			return (this.quotaInfo ?? []).map((q, idx) => ({ id: idx, label: q.type }))
+		},
+		downloadQuotaUsageUrl() {
+			return generateUrl('/apps/integration_openai/quota/download-usage?type={type}&startDate={startDate}&endDate={endDate}', {
+				type: this.quota_usage.quota_type?.id,
+				startDate: this.quota_usage.start_date / 1000,
+				endDate: this.quota_usage.end_date / 1000,
+			})
+		},
 		modelEndpointUrl() {
 			if (this.state.url === '') {
 				return 'https://api.openai.com/v1/models'
@@ -821,6 +854,9 @@ export default {
 			return axios.get(url)
 				.then((response) => {
 					this.quotaInfo = response.data
+					if (this.quotaInfo.length > 0) {
+						this.quota_usage.quota_type = { id: 0, label: this.quotaInfo[0].type }
+					}
 				})
 				.catch((error) => {
 					showError(
@@ -947,8 +983,24 @@ export default {
 	}
 
 	.line {
-		display: flex;
 		align-items: center;
+	}
+
+	.line-gap {
+		gap: 8px;
+		align-items: normal;
+
+		.download-button {
+			align-self: flex-end;
+		}
+
+		> * {
+			margin-bottom: 20px;
+		}
+	}
+
+	.line, .line-gap {
+		display: flex;
 		margin-top: 12px;
 		.icon {
 			margin-right: 4px;


### PR DESCRIPTION
Resolves: #250 
<img width="966" height="449" alt="image" src="https://github.com/user-attachments/assets/11a7c68a-ff20-4c26-8836-b68044b12541" />
Currently downloads a csv that looks like the sample below sorted by usage which is why it currently requires filtering the category:
[quota_usage.csv](https://github.com/user-attachments/files/21903953/quota_usage.csv)
Also does double count usage if used in a pool then it counts for the user and the pool in the report. Ex: users alice and bob are in a pool. Alice used 20 tokens, bob 300 tokens. The csv would look like this

User | Usage
-- | --
Pool for Rule 1 | 320
Bob | 300
Alice | 20

- [x] Use as default start and end date the current quota period