### PR TITLE
feat: add config for disabling the quota webui

### DIFF
--- a/lib/Service/OpenAiSettingsService.php
+++ b/lib/Service/OpenAiSettingsService.php
@@ -679,6 +679,7 @@ class OpenAiSettingsService {
 			}
 		}
 
+		$quotaDisabled = $this->config->getSystemValue('integration_openai.disable_webui_quota', false);
 		// Validation of the input values is done in the individual setters
 		if (isset($adminConfig['request_timeout'])) {
 			$this->setRequestTimeout($adminConfig['request_timeout']);
@@ -722,10 +723,10 @@ class OpenAiSettingsService {
 		if (isset($adminConfig['llm_extra_params'])) {
 			$this->setLlmExtraParams($adminConfig['llm_extra_params']);
 		}
-		if (isset($adminConfig['quota_period'])) {
+		if (isset($adminConfig['quota_period']) && !$quotaDisabled) {
 			$this->setQuotaPeriod($adminConfig['quota_period']);
 		}
-		if (isset($adminConfig['quotas'])) {
+		if (isset($adminConfig['quotas']) && !$quotaDisabled) {
 			$this->setQuotas($adminConfig['quotas']);
 		}
 		if (isset($adminConfig['use_max_completion_tokens_param'])) {

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -12,6 +12,7 @@ use OCA\OpenAi\Service\OpenAiSettingsService;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
+use OCP\IConfig;
 use OCP\Settings\ISettings;
 
 class Admin implements ISettings {
@@ -19,6 +20,7 @@ class Admin implements ISettings {
 		private IInitialState $initialStateService,
 		private OpenAiSettingsService $openAiSettingsService,
 		private IAppManager $appManager,
+		private IConfig $config,
 	) {
 	}
 
@@ -31,6 +33,7 @@ class Admin implements ISettings {
 		$adminConfig['basic_password'] = $adminConfig['basic_password'] === '' ? '' : 'dummyPassword';
 		$isAssistantEnabled = $this->appManager->isEnabledForUser('assistant');
 		$adminConfig['assistant_enabled'] = $isAssistantEnabled;
+		$adminConfig['disable_webui_quota'] = $this->config->getSystemValue('integration_openai.disable_webui_quota', false);
 		$this->initialStateService->provideInitialState('admin-config', $adminConfig);
 		return new TemplateResponse(Application::APP_ID, 'adminSettings');
 	}

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -498,6 +498,9 @@
 				<h2>
 					{{ t('integration_openai', 'Usage limits') }}
 				</h2>
+				<NcNoteCard v-if="state.disable_webui_quota" type="warning">
+					{{ t('integration_openai', 'The webui for quota enforcement is disabled in the config.') }}
+				</NcNoteCard>
 				<div class="line">
 					<!--Time period in days for the token usage-->
 					<NcInputField
@@ -507,6 +510,7 @@
 						type="number"
 						:label="t('integration_openai', 'Quota enforcement time period (days)')"
 						:show-trailing-button="!!state.quota_period"
+						:disabled="state.disable_webui_quota"
 						@update:model-value="onInput()"
 						@trailing-button-click="state.quota_period = '' ; onInput()">
 						<template #trailing-button-icon>
@@ -545,6 +549,7 @@
 									v-model.number="state.quotas[index]"
 									:title="t('integration_openai', 'A per-user limit for usage of this API type (0 for unlimited)')"
 									type="number"
+									:disabled="state.disable_webui_quota"
 									@input="onInput()">
 								<span v-if="quotaInfo !== null" class="text-cell">
 									{{ quotaInfo[index].unit }}


### PR DESCRIPTION
This disables the webui in the admin settings for quota when `integration_openai.disable_webui_quota` is set to true in config.php.
Screenshot when quota for webui is disabled
<img width="969" height="479" alt="image" src="https://github.com/user-attachments/assets/32080920-385c-459d-90fa-f3ac5760751f" />
