### PR TITLE
fix: change default completion model to 4.1 mini

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -40,7 +40,7 @@ class Application extends App implements IBootstrap {
 	public const USER_AGENT = 'Nextcloud OpenAI/LocalAI integration';
 
 	public const DEFAULT_MODEL_ID = 'Default';
-	public const DEFAULT_COMPLETION_MODEL_ID = 'gpt-3.5-turbo';
+	public const DEFAULT_COMPLETION_MODEL_ID = 'gpt-4.1-mini';
 	public const DEFAULT_IMAGE_MODEL_ID = 'dall-e-2';
 	public const DEFAULT_TRANSCRIPTION_MODEL_ID = 'whisper-1';
 	public const DEFAULT_SPEECH_MODEL_ID = 'tts-1-hd';

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -775,7 +775,7 @@ export default {
 					}
 					const defaultCompletionModelId = this.state.default_completion_model_id || response.data?.default_completion_model_id
 					const completionModelToSelect = this.models.find(m => m.id === defaultCompletionModelId)
-						|| this.models.find(m => m.id === 'gpt-3.5-turbo')
+						|| this.models.find(m => m.id === 'gpt-4.1-mini')
 						|| this.models[1]
 						|| this.models[0]
 


### PR DESCRIPTION
Fix: #261 
This doesn't actually change the default for analyze image because it turns out most openai models support images as input, but instead changes the default model to gpt-4.1-mini as it is around the same price as gpt-3.5-turbo, but better.