### PR TITLE
Store the model list in the DB

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -101,7 +101,7 @@ Negative:
 
 Learn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud.com/blog/nextcloud-ethical-ai-rating/).
 ]]>	</description>
-	<version>3.8.0</version>
+	<version>3.9.0</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>OpenAi</namespace>
@@ -121,6 +121,7 @@ Learn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud
 	</dependencies>
 	<background-jobs>
 		<job>OCA\OpenAi\Cron\CleanupQuotaDb</job>
+		<job>OCA\OpenAi\Cron\RefreshModels</job>
 	</background-jobs>
 	<settings>
 		<admin>OCA\OpenAi\Settings\Admin</admin>

--- a/lib/Controller/OpenAiAPIController.php
+++ b/lib/Controller/OpenAiAPIController.php
@@ -31,7 +31,7 @@ class OpenAiAPIController extends Controller {
 	#[NoAdminRequired]
 	public function getModels(): DataResponse {
 		try {
-			$response = $this->openAiAPIService->getModels($this->userId);
+			$response = $this->openAiAPIService->getModels($this->userId, true);
 			return new DataResponse($response);
 		} catch (Exception $e) {
 			$code = $e->getCode() === 0 ? Http::STATUS_BAD_REQUEST : intval($e->getCode());

--- a/lib/Cron/RefreshModels.php
+++ b/lib/Cron/RefreshModels.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\OpenAi\Cron;
+
+use OCA\OpenAi\Service\OpenAiAPIService;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\TimedJob;
+use Psr\Log\LoggerInterface;
+
+class RefreshModels extends TimedJob {
+	public function __construct(
+		ITimeFactory $time,
+		private OpenAiAPIService $openAIAPIService,
+		private LoggerInterface $logger,
+	) {
+		parent::__construct($time);
+		$this->setInterval(60 * 60 * 24); // Daily
+	}
+
+	protected function run($argument) {
+		$this->logger->debug('Run daily model refresh job');
+		$this->openAIAPIService->getModels(null, true);
+	}
+}

--- a/lib/Migration/Version030900Date20251006152735.php
+++ b/lib/Migration/Version030900Date20251006152735.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 

--- a/lib/Migration/Version030900Date20251006152735.php
+++ b/lib/Migration/Version030900Date20251006152735.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\OpenAi\Migration;
+
+use Closure;
+use OCA\OpenAi\Service\OpenAiAPIService;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version030900Date20251006152735 extends SimpleMigrationStep {
+
+	public function __construct(
+		private OpenAIAPIService $openAIAPIService,
+	) {
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure
+	 * @param array $options
+	 */
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+		// we refresh the model list to make sure they are stored in oc_appconfig
+		// so they are available immediately after the app upgrade to populate the task types enum values
+		$this->openAIAPIService->getModels(null, true);
+	}
+}


### PR DESCRIPTION
closes #272

This prevents the model list to be obtained with a network request to the external service when populating the enum values of the task processing providers (which is a problem when the remote service is unreachable).

We now store the model list in a permanent storage (the DB) and it is only refreshed:
* when the settings page is accessed
* on upgrade to 3.9.0
* once a day in a bg job