### PR TITLE
fix: catch errors in model fetch during migration

### DIFF
--- a/lib/Migration/Version030900Date20251006152735.php
+++ b/lib/Migration/Version030900Date20251006152735.php
@@ -29,6 +29,9 @@ class Version030900Date20251006152735 extends SimpleMigrationStep {
 	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
 		// we refresh the model list to make sure they are stored in oc_appconfig
 		// so they are available immediately after the app upgrade to populate the task types enum values
-		$this->openAIAPIService->getModels(null, true);
+		try {
+			$this->openAIAPIService->getModels(null, true);
+		} catch (\Exception) {
+		}
 	}
 }


### PR DESCRIPTION
the cache is cleared by the function so our job is done here.
when an api key would be set/changed, it would fetch the models again anyway.

resolves #288