### PR TITLE
Adjust audio input chat message format

### DIFF
--- a/lib/Service/OpenAiAPIService.php
+++ b/lib/Service/OpenAiAPIService.php
@@ -560,7 +560,7 @@ class OpenAiAPIService {
 						'type' => 'input_audio',
 						'input_audio' => [
 							'data' => $userAudioPromptBase64,
-							'format' => 'mp3',
+							'format' => 'wav',
 						],
 					],
 				],


### PR DESCRIPTION
The assistant now produces wav audio input so we need to change the input param in the chat completion request with multimodal model.

* See https://github.com/nextcloud/assistant/pull/413