### PR TITLE
Detect audio input format

### DIFF
--- a/lib/Service/OpenAiAPIService.php
+++ b/lib/Service/OpenAiAPIService.php
@@ -490,6 +490,7 @@ class OpenAiAPIService {
 	 * @param string|null $toolMessage JSON string with role, content, tool_call_id
 	 * @param array|null $tools
 	 * @param string|null $userAudioPromptBase64
+	 * @param string|null $userAudioPromptFormat
 	 * @return array{messages: array<string>, tool_calls: array<string>, audio_messages: list<array<string, mixed>>}
 	 * @throws Exception
 	 */
@@ -505,6 +506,7 @@ class OpenAiAPIService {
 		?string $toolMessage = null,
 		?array $tools = null,
 		?string $userAudioPromptBase64 = null,
+		?string $userAudioPromptFormat = null,
 	): array {
 		if ($this->isQuotaExceeded($userId, Application::QUOTA_TYPE_TEXT)) {
 			throw new Exception($this->l10n->t('Text generation quota exceeded'), Http::STATUS_TOO_MANY_REQUESTS);
@@ -560,7 +562,7 @@ class OpenAiAPIService {
 						'type' => 'input_audio',
 						'input_audio' => [
 							'data' => $userAudioPromptBase64,
-							'format' => 'wav',
+							'format' => $userAudioPromptFormat ?? 'wav',
 						],
 					],
 				],


### PR DESCRIPTION
 Detect audio input format when sending it as a message to the chat completion endpoint.
OpenAI support wav and mp3, so do we.

This makes integration_openai work whether the assistant is recording/producing wav or mp3 audio messages. (We switched from mp3 to wav in https://github.com/nextcloud/assistant/pull/413 )

Tested with the assistant before and after https://github.com/nextcloud/assistant/pull/413 . With wav I get `audio/x-wav` as mimetype and with mp3 we get `audio/mpeg`. I decided to add support for `audio/mp3` and `audio/wav` just in case.

