### PR TITLE
Prepare 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 4.2.0 - 2025-01-16
+
+### Added
+
+- Support multiple providers @lukasdotcom [#311](https://github.com/nextcloud/integration_openai/pull/311)
+
+### Changed
+
+- Use structured output in the translation provider to limit extraneous text @kyteinsky [#326](https://github.com/nextcloud/integration_openai/pull/326)
+
+### Fixed
+
+- Handle empty userIds in quota accounting @kyteinsky [#319](https://github.com/nextcloud/integration_openai/pull/319)
+
 ## 4.1.1 - 2025-01-14
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -101,7 +101,7 @@ Negative:
 
 Learn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud.com/blog/nextcloud-ethical-ai-rating/).
 ]]>	</description>
-	<version>4.1.1</version>
+	<version>4.2.0</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>OpenAi</namespace>


### PR DESCRIPTION
### Added

- Support multiple providers @lukasdotcom [#311](https://github.com/nextcloud/integration_openai/pull/311)

### Changed

- Use structured output in the translation provider to limit extraneous text @kyteinsky [#326](https://github.com/nextcloud/integration_openai/pull/326)

### Fixed

- Handle empty userIds in quota accounting @kyteinsky [#319](https://github.com/nextcloud/integration_openai/pull/319)