### PR TITLE
Fix incorrect method call in updateExpTextProcessingTime()

### DIFF
--- a/lib/Service/OpenAiAPIService.php
+++ b/lib/Service/OpenAiAPIService.php
@@ -953,7 +953,7 @@ class OpenAiAPIService {
 	 * @return void
 	 */
 	public function updateExpTextProcessingTime(int $runtime): void {
-		$oldTime = floatval($this->getExpImgProcessingTime());
+		$oldTime = floatval($this->getExpTextProcessingTime());
 		$newTime = (1.0 - Application::EXPECTED_RUNTIME_LOWPASS_FACTOR) * $oldTime + Application::EXPECTED_RUNTIME_LOWPASS_FACTOR * floatval($runtime);
 
 		if ($this->isUsingOpenAi()) {


### PR DESCRIPTION
This commit fixes a bug where the method updateExpTextProcessingTime incorrectly called getExpImgProcessingTime. The change ensures that text and image processing times are tracked independently.

## Description

Fixes a bug in `updateExpTextProcessingTime()` where it incorrectly calls `getExpImgProcessingTime()` instead of `getExpTextProcessingTime()`. This causes database type conflicts when processing text generation tasks.

## The Bug

**File**: `lib/Service/OpenAiAPIService.php`
**Line**: 850

The function reads **image** processing time configuration when it should read **text** processing time configuration:

```php
public function updateExpTextProcessingTime(int $runtime): void {
    $oldTime = floatval($this->getExpImgProcessingTime());  // ❌ Wrong method
    // ...
}
```

This causes a mismatch between:
- **Read**: `openai_image_generation_time` / `localai_image_generation_time`
- **Write**: `openai_text_generation_time` / `localai_text_generation_time`

## Impact

### Error Message
```
RuntimeException: OpenAI/LocalAI request failed: conflict with value type from database
```

### When it Occurs
- Background job processing for TaskProcessing text generation tasks
- All text-based AI operations (FreePrompt, Summary, Headline, etc.)
- Both OpenAI and LocalAI endpoints affected

### Affected Versions
- Introduced in v3.6.0 (commit e1ffaba - "psalm fixes", April 4, 2025)
- Present in all subsequent versions through current v4.2.0

## The Fix

Change line 850 to call the correct method:

```diff
  public function updateExpTextProcessingTime(int $runtime): void {
-     $oldTime = floatval($this->getExpImgProcessingTime());
+     $oldTime = floatval($this->getExpTextProcessingTime());
      $newTime = (1.0 - Application::EXPECTED_RUNTIME_LOWPASS_FACTOR) * $oldTime + Application::EXPECTED_RUNTIME_LOWPASS_FACTOR * floatval($runtime);
```

## Root Cause

Copy-paste error when `updateExpTextProcessingTime()` was created. The corresponding `updateExpImgProcessingTime()` method (line 774) correctly calls `getExpImgProcessingTime()`, but this pattern wasn't updated for the text processing variant.

## Testing

The fix ensures:
1. Text processing time metrics are properly tracked
2. No database type conflicts when reading/writing config values
3. Proper exponential moving average calculation for text generation times

## Reproduction

1. Configure LocalAI or OpenAI endpoint
2. Trigger any text generation task via Assistant
3. Background job worker processes the task
4. Error occurs when trying to update processing time metrics

## Stack Trace Context

```
File: /var/www/html/lib/private/TaskProcessing/Manager.php:949
  -> OCA\OpenAi\TaskProcessing\TextToTextProvider->process()

File: /var/www/html/apps-external/integration_openai/lib/TaskProcessing/TextToTextProvider.php:135
  -> RuntimeException: OpenAI/LocalAI request failed: conflict with value type from database
```

---

**Checklist**
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tested locally
- [x] One-line change, minimal risk
- [x] No new dependencies
- [x] Maintains backward compatibility