### PR TITLE
Fix empty model list for image, tts, and stt when not overriden

### DIFF
--- a/lib/Cron/RefreshModels.php
+++ b/lib/Cron/RefreshModels.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OCA\OpenAi\Cron;
 
+use OCA\OpenAi\AppInfo\Application;
 use OCA\OpenAi\Service\OpenAiAPIService;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
@@ -27,5 +28,9 @@ class RefreshModels extends TimedJob {
 	protected function run($argument) {
 		$this->logger->debug('Run daily model refresh job');
 		$this->openAIAPIService->getModels(null, true);
+		$this->openAIAPIService->getModels(null, true, Application::SERVICE_TYPE_TTS);
+		$this->openAIAPIService->getModels(null, true, Application::SERVICE_TYPE_STT);
+		$this->openAIAPIService->getModels(null, true, Application::SERVICE_TYPE_IMAGE);
+
 	}
 }

--- a/lib/Service/OpenAiAPIService.php
+++ b/lib/Service/OpenAiAPIService.php
@@ -142,6 +142,14 @@ class OpenAiAPIService {
 	 * @throws Exception
 	 */
 	public function getModels(?string $userId, bool $refresh = false, ?string $serviceType = null): array {
+		// Use default service type if service type is not overridden
+		if ($serviceType === Application::SERVICE_TYPE_IMAGE && !$this->openAiSettingsService->imageOverrideEnabled()) {
+			$serviceType = null;
+		} elseif ($serviceType === Application::SERVICE_TYPE_STT && !$this->openAiSettingsService->sttOverrideEnabled()) {
+			$serviceType = null;
+		} elseif ($serviceType === Application::SERVICE_TYPE_TTS && !$this->openAiSettingsService->ttsOverrideEnabled()) {
+			$serviceType = null;
+		}
 		$cache = $this->cacheFactory->createDistributed(Application::APP_ID);
 		$userCacheKey = Application::MODELS_CACHE_KEY . '_' . ($userId ?? '') . '_' . ($serviceType ?? 'main');
 		$adminCacheKey = Application::MODELS_CACHE_KEY . '-main' . '_' . ($serviceType ?? 'main');


### PR DESCRIPTION
Issue was that the cache wasn't prepopulated for image if the service wasn't overridden.

Resolves: #340