### PR TITLE
Prepare 4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 4.3.0 - 2026-02-26
+
+### Changed
+
+- Update checkboxes to use new NcFormBoxSwitch component @lukasdotcom [#343](https://github.com/nextcloud/integration_openai/pull/343)
+
+### Fixed
+
+- Fix incorrect method call in updateExpTetProcessingTime @printminion-co [#334](https://github.com/nextcloud/integration_openai/pull/334)
+- Fix empty model list for image, tts, and stt when not overriden @lukasdotcom [#342](https://github.com/nextcloud/integration_openai/pull/342)
+- Fix wrong user config error @lukasdotcom [#341](https://github.com/nextcloud/integration_openai/pull/341)
+
 ## 4.2.0 - 2026-01-16
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -101,7 +101,7 @@ Negative:
 
 Learn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud.com/blog/nextcloud-ethical-ai-rating/).
 ]]>	</description>
-	<version>4.2.0</version>
+	<version>4.3.0</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>OpenAi</namespace>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "integration_openai",
-  "version": "1.2.0",
+  "version": "4.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "integration_openai",
-      "version": "1.2.0",
+      "version": "4.3.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integration_openai",
-  "version": "1.2.0",
+  "version": "4.3.0",
   "description": "OpenAI integration",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
## 4.3.0 - 2026-02-26

### Changed

- Update checkboxes to use new NcFormBoxSwitch component @lukasdotcom [#343](https://github.com/nextcloud/integration_openai/pull/343)

### Fixed

- Fix incorrect method call in updateExpTetProcessingTime @printminion-co [#334](https://github.com/nextcloud/integration_openai/pull/334)
- Fix empty model list for image, tts, and stt when not overriden @lukasdotcom [#342](https://github.com/nextcloud/integration_openai/pull/342)
- Fix wrong user config error @lukasdotcom [#341](https://github.com/nextcloud/integration_openai/pull/341)