### PR TITLE
fix: Ensure tool message content is a string

### DIFF
--- a/lib/Service/OpenAiAPIService.php
+++ b/lib/Service/OpenAiAPIService.php
@@ -623,6 +623,10 @@ class OpenAiAPIService {
 			$msgs = json_decode($toolMessage, true);
 			foreach ($msgs as $msg) {
 				$msg['role'] = 'tool';
+				if (!is_string($msg['content'])) {
+					// IONOS requires tool contents to be strings
+					$msg['content'] = json_encode($msg['content']);
+				}
 				$messages[] = $msg;
 			}
 		}


### PR DESCRIPTION
IONOS requires this

### example

Request:
```
... "messages": [
...

{"role": "tool", "tool_call_id": "chatcmpl-tool-dfae4ca4af3742b2b0f39d34bc090e9d", "content": {"address":"Heuptstraße 3, 12345 Berlin"}}

]
...
```

Response: (Failure)

```
{
  "error": {
    "message": "1 validation error for ValidatorIterator\n0\n  Input should be a valid dictionary [type=dict_type, input_value='address', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.12/v/dict_type None",
    "type": "BadRequestError",
    "param": null,
    "code": 400
  }
}
```

### example 2

Request:

```
... "messages": [

{"role": "tool", "tool_call_id": "chatcmpl-tool-dfae4ca4af3742b2b0f39d34bc090e9d", "content": "Heuptstraße 3, 12345 Mannheim"}
]
...
```

Response: (OK)

```
{
  "id": "chatcmpl-6326d05f-10fc-98f8-843e-1c2028f4507a",
  "object": "chat.completion",
  "created": 1777448721,
  "model": "mistralai/Mistral-Small-24B-Instruct",
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "content": "Andrew's address is Heuptstraße 3, 12345 Mannheim.",
        "refusal": null,
        "annotations": null,
        "audio": null,
        "function_call": null,
        "tool_calls": [],
        "reasoning": null,
        "reasoning_content": null
      },
      "logprobs": null,
      "finish_reason": "stop",
      "stop_reason": null,
      "token_ids": null
    }
  ],
  "service_tier": null,
  "system_fingerprint": null,
  "usage": {
    "prompt_tokens": 3183,
    "total_tokens": 3202,
    "completion_tokens": 19,
    "prompt_tokens_details": null
  },
  "prompt_logprobs": null,
  "prompt_token_ids": null,
  "kv_transfer_params": null
}
```