### PR TITLE
Prepare 4.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [4.4.0] - 2026-05-04
+
+### Added
+
+- Add retry logic for HTTP 429 responses in OpenAiAPIService @marcelklehr [#359](https://github.com/nextcloud/integration_openai/pull/359)
+
+### Fixed
+
+- Use static language list instead of l10nFactory for translation providers @bakiburakogun [#358](https://github.com/nextcloud/integration_openai/pull/358)
+- Ensure tool message content is a string @marcelklehr [#360](https://github.com/nextcloud/integration_openai/pull/360)
+
 ## [4.3.1] - 2026-03-31
 
 ### Changed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -101,7 +101,7 @@ Negative:
 
 Learn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud.com/blog/nextcloud-ethical-ai-rating/).
 ]]>	</description>
-	<version>4.3.1</version>
+	<version>4.4.0</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>OpenAi</namespace>
@@ -117,7 +117,7 @@ Learn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud
 	<screenshot>https://github.com/nextcloud/integration_openai/raw/main/img/screenshot3.jpg</screenshot>
 	<screenshot>https://github.com/nextcloud/integration_openai/raw/main/img/screenshot4.jpg</screenshot>
 	<dependencies>
-		<nextcloud min-version="33" max-version="33"/>
+		<nextcloud min-version="33" max-version="34"/>
 	</dependencies>
 	<background-jobs>
 		<job>OCA\OpenAi\Cron\CleanupQuotaDb</job>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "integration_openai",
-  "version": "4.3.1",
+  "version": "4.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "integration_openai",
-      "version": "4.3.1",
+      "version": "4.4.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integration_openai",
-  "version": "4.3.1",
+  "version": "4.4.0",
   "description": "OpenAI integration",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
## [4.4.0] - 2026-05-04

### Added

- Add retry logic for HTTP 429 responses in OpenAiAPIService @marcelklehr [#359](https://github.com/nextcloud/integration_openai/pull/359)

### Fixed

- Use static language list instead of l10nFactory for translation providers @bakiburakogun [#358](https://github.com/nextcloud/integration_openai/pull/358)
- Ensure tool message content is a string @marcelklehr [#360](https://github.com/nextcloud/integration_openai/pull/360)