### PR TITLE
Fix/max tokens hardcoded

### DIFF
--- a/lib/TaskProcessing/HeadlineProvider.php
+++ b/lib/TaskProcessing/HeadlineProvider.php
@@ -82,7 +82,7 @@ class HeadlineProvider implements ISynchronousProvider {
 			? ($this->appConfig->getValueString(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID, lazy: true) ?: Application::DEFAULT_MODEL_ID)
 			: $this->appConfig->getValueString(Application::APP_ID, 'default_completion_model_id', lazy: true);
 		return [
-			'max_tokens' => 1000,
+			'max_tokens' => $this->openAiSettingsService->getMaxTokens(),
 			'model' => $adminModel,
 		];
 	}

--- a/lib/TaskProcessing/HeadlineProvider.php
+++ b/lib/TaskProcessing/HeadlineProvider.php
@@ -82,7 +82,7 @@ class HeadlineProvider implements ISynchronousProvider {
 			? ($this->appConfig->getValueString(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID, lazy: true) ?: Application::DEFAULT_MODEL_ID)
 			: $this->appConfig->getValueString(Application::APP_ID, 'default_completion_model_id', lazy: true);
 		return [
-			'max_tokens' => $this->openAiSettingsService->getMaxTokens(),
+			'max_tokens' => 100,
 			'model' => $adminModel,
 		];
 	}

--- a/lib/TaskProcessing/TextToTextProvider.php
+++ b/lib/TaskProcessing/TextToTextProvider.php
@@ -82,7 +82,7 @@ class TextToTextProvider implements ISynchronousProvider {
 			? ($this->appConfig->getValueString(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID, lazy: true) ?: Application::DEFAULT_MODEL_ID)
 			: $this->appConfig->getValueString(Application::APP_ID, 'default_completion_model_id', lazy: true);
 		return [
-			'max_tokens' => 1000,
+			'max_tokens' => $this->openAiSettingsService->getMaxTokens(),
 			'model' => $adminModel,
 		];
 	}

--- a/lib/TaskProcessing/TopicsProvider.php
+++ b/lib/TaskProcessing/TopicsProvider.php
@@ -86,7 +86,7 @@ class TopicsProvider implements ISynchronousProvider {
 			? ($this->appConfig->getValueString(Application::APP_ID, 'default_completion_model_id', Application::DEFAULT_MODEL_ID, lazy: true) ?: Application::DEFAULT_MODEL_ID)
 			: $this->appConfig->getValueString(Application::APP_ID, 'default_completion_model_id', lazy: true);
 		return [
-			'max_tokens' => 1000,
+			'max_tokens' => $this->openAiSettingsService->getMaxTokens(),
 			'model' => $adminModel,
 		];
 	}


### PR DESCRIPTION
We noticed some occurrences of 'max_tokens' => 1000 in the Nextcloud codebase, specifically in:
- apps/integration_openai/lib/TaskProcessing/TextToTextProvider.php
- apps/integration_openai/lib/TaskProcessing/HeadlineProvider.php
- apps/integration_openai/lib/TaskProcessing/TopicsProvider.php

This prevents requests from being executed in full, and leads to half-generated documents or truncated answers, which ruins the user experience.

We replaced those faulty lines with:
'max_tokens' => $this->openAiSettingsService->getMaxTokens()