### PR TITLE
Switch from dall-e-2 to gpt-image-1-mini

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -43,7 +43,7 @@ class Application extends App implements IBootstrap {
 
 	public const DEFAULT_MODEL_ID = 'Default';
 	public const DEFAULT_COMPLETION_MODEL_ID = 'gpt-4.1-mini';
-	public const DEFAULT_IMAGE_MODEL_ID = 'dall-e-2';
+	public const DEFAULT_IMAGE_MODEL_ID = 'gpt-image-1-mini';
 	public const DEFAULT_TRANSCRIPTION_MODEL_ID = 'whisper-1';
 	public const DEFAULT_SPEECH_MODEL_ID = 'tts-1-hd';
 	public const DEFAULT_SPEECH_VOICE = 'alloy';

--- a/lib/Service/OpenAiAPIService.php
+++ b/lib/Service/OpenAiAPIService.php
@@ -93,7 +93,7 @@ class OpenAiAPIService {
 	public function getServiceName(?string $serviceType = null): string {
 		if ($this->isUsingOpenAi($serviceType)) {
 			if ($serviceType === Application::SERVICE_TYPE_IMAGE) {
-				return $this->l10n->t('OpenAI\'s DALL-E 2');
+				return $this->l10n->t('OpenAI\'s Image Generation');
 			}
 			if ($serviceType === Application::SERVICE_TYPE_TTS) {
 				$this->l10n->t('OpenAI\'s Text to Speech');

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -822,7 +822,7 @@ export default {
 
 			const defaultImageModelId = this.state.default_image_model_id
 			const imageModelToSelect = this.imageModels.find(m => m.id === defaultImageModelId)
-					|| this.imageModels.find(m => m.id === 'dall-e-2')
+					|| this.imageModels.find(m => m.id.match(/image/i))
 					|| this.imageModels[1]
 					|| this.imageModels[0]
 


### PR DESCRIPTION
Dall-e-2 was discontinued 2 days ago. It might also be worth it to create a migration to automatically do this switch for users.