### PR TITLE
models api route only for admins and use instance api key

### DIFF
--- a/lib/Controller/OpenAiAPIController.php
+++ b/lib/Controller/OpenAiAPIController.php
@@ -29,10 +29,9 @@ class OpenAiAPIController extends Controller {
 	 * @param string|null $serviceType
 	 * @return DataResponse
 	 */
-	#[NoAdminRequired]
 	public function getModels(?string $serviceType = null): DataResponse {
 		try {
-			$response = $this->openAiAPIService->getModels($this->userId, true, $serviceType);
+			$response = $this->openAiAPIService->getModels(null, true, $serviceType);
 			return new DataResponse($response);
 		} catch (Exception $e) {
 			$code = $e->getCode() === 0 ? Http::STATUS_BAD_REQUEST : intval($e->getCode());


### PR DESCRIPTION
Not sure if this route is used anywhere other than the admin settings page. I couldn't find it though. It would also resolve an issue.
Resolves: #348 