### PR TITLE
Stop processing when a task is cancelled

### DIFF
--- a/lib/TaskProcessing/AnalyzeImagesProvider.php
+++ b/lib/TaskProcessing/AnalyzeImagesProvider.php
@@ -217,18 +217,24 @@ class AnalyzeImagesProvider implements IProvider, ISynchronousOptionsAwareProvid
 					}
 					// we don't report more often than every 250ms
 					if (microtime(true) - $time >= 0.25) {
-						$reportOutput([
+						$running = $reportOutput([
 							'output' => $streamedOutput,
 							'reasoning' => $streamedReasoning,
 						]);
+						if (!$running) {
+							throw new ProcessingException('OpenAI/LocalAI task cancelled');
+						}
 						$time = microtime(true);
 					}
 				}
 				if ($streamedOutput !== '' || $streamedReasoning !== '') {
-					$reportOutput([
+					$running = $reportOutput([
 						'output' => $streamedOutput,
 						'reasoning' => $streamedReasoning,
 					]);
+					if (!$running) {
+						throw new ProcessingException('OpenAI/LocalAI task cancelled');
+					}
 				}
 				$returnValue = $chunks->getReturn();
 				$completion = $returnValue['messages'];

--- a/lib/TaskProcessing/AudioToAudioTranslateProvider.php
+++ b/lib/TaskProcessing/AudioToAudioTranslateProvider.php
@@ -191,9 +191,12 @@ class AudioToAudioTranslateProvider implements IProvider, ISynchronousOptionsAwa
 		$reportProgress(0.3);
 
 		if ($preferStreaming) {
-			$reportOutput([
+			$running = $reportOutput([
 				'text_input' => $transcription . $watermarkSuffix,
 			]);
+			if (!$running) {
+				throw new ProcessingException('OpenAI/LocalAI task cancelled');
+			}
 		}
 
 		// translate
@@ -204,10 +207,13 @@ class AudioToAudioTranslateProvider implements IProvider, ISynchronousOptionsAwa
 
 		try {
 			$reportTranslationOutput = function (string $translationOutput) use ($reportOutput, $transcription, $watermarkSuffix) {
-				$reportOutput([
+				$running = $reportOutput([
 					'text_input' => $transcription . $watermarkSuffix,
 					'text_output' => $translationOutput,
 				]);
+				if (!$running) {
+					throw new ProcessingException('OpenAI/LocalAI task cancelled');
+				}
 			};
 			$translatedText = $this->translateService->translate(
 				$transcription, $input['origin_language'], $input['target_language'],
@@ -216,10 +222,13 @@ class AudioToAudioTranslateProvider implements IProvider, ISynchronousOptionsAwa
 			);
 
 			if ($preferStreaming) {
-				$reportOutput([
+				$running = $reportOutput([
 					'text_input' => $transcription . $watermarkSuffix,
 					'text_output' => $translatedText . $watermarkSuffix,
 				]);
+				if (!$running) {
+					throw new ProcessingException('OpenAI/LocalAI task cancelled');
+				}
 			}
 
 			if (empty($translatedText)) {

--- a/lib/TaskProcessing/ChangeToneProvider.php
+++ b/lib/TaskProcessing/ChangeToneProvider.php
@@ -166,18 +166,24 @@ class ChangeToneProvider implements IProvider, ISynchronousOptionsAwareProvider 
 							}
 							// we don't report more often than every 250ms
 							if (microtime(true) - $time >= 0.25) {
-								$reportOutput([
+								$running = $reportOutput([
 									'output' => $streamedOutput,
 									'reasoning' => $streamedReasoning,
 								]);
+								if (!$running) {
+									throw new ProcessingException('OpenAI/LocalAI task cancelled');
+								}
 								$time = microtime(true);
 							}
 						}
 						if ($streamedOutput !== '' || $streamedReasoning !== '') {
-							$reportOutput([
+							$running = $reportOutput([
 								'output' => $streamedOutput,
 								'reasoning' => $streamedReasoning,
 							]);
+							if (!$running) {
+								throw new ProcessingException('OpenAI/LocalAI task cancelled');
+							}
 						}
 						$returnValue = $chunks->getReturn();
 						$completion = $returnValue['messages'];

--- a/lib/TaskProcessing/ChangeToneProvider.php
+++ b/lib/TaskProcessing/ChangeToneProvider.php
@@ -203,7 +203,10 @@ class ChangeToneProvider implements IProvider, ISynchronousOptionsAwareProvider 
 				throw new ProcessingException('OpenAI/LocalAI request failed: ' . $e->getMessage());
 			}
 			$progress += $increase;
-			$reportProgress($progress);
+			$running = $reportProgress($progress);
+			if (!$running) {
+				throw new ProcessingException('OpenAI/LocalAI task cancelled');
+			}
 			if (count($reasoning) > 0) {
 				$fullReasoning .= array_pop($reasoning);
 			}

--- a/lib/TaskProcessing/ContextWriteProvider.php
+++ b/lib/TaskProcessing/ContextWriteProvider.php
@@ -209,7 +209,10 @@ class ContextWriteProvider implements IProvider, ISynchronousOptionsAwareProvide
 			if (count($completion) > 0) {
 				$fullOutput .= array_pop($completion);
 				$progress += $increase;
-				$reportProgress($progress);
+				$running = $reportProgress($progress);
+				if (!$running) {
+					throw new ProcessingException('OpenAI/LocalAI task cancelled');
+				}
 				continue;
 			}
 

--- a/lib/TaskProcessing/ContextWriteProvider.php
+++ b/lib/TaskProcessing/ContextWriteProvider.php
@@ -167,18 +167,24 @@ class ContextWriteProvider implements IProvider, ISynchronousOptionsAwareProvide
 							}
 							// we don't report more often than every 250ms
 							if (microtime(true) - $time >= 0.25) {
-								$reportOutput([
+								$running = $reportOutput([
 									'output' => $streamedOutput,
 									'reasoning' => $streamedReasoning,
 								]);
+								if (!$running) {
+									throw new ProcessingException('OpenAI/LocalAI task cancelled');
+								}
 								$time = microtime(true);
 							}
 						}
 						if ($streamedOutput !== '' || $streamedReasoning !== '') {
-							$reportOutput([
+							$running = $reportOutput([
 								'output' => $streamedOutput,
 								'reasoning' => $streamedReasoning,
 							]);
+							if (!$running) {
+								throw new ProcessingException('OpenAI/LocalAI task cancelled');
+							}
 						}
 						$returnValue = $chunks->getReturn();
 						$completion = $returnValue['messages'];

--- a/lib/TaskProcessing/ProofreadProvider.php
+++ b/lib/TaskProcessing/ProofreadProvider.php
@@ -139,7 +139,10 @@ class ProofreadProvider implements ISynchronousProvider {
 			if (count($completion) > 0) {
 				$result .= array_pop($completion);
 				$progress += $increase;
-				$reportProgress($progress);
+				$running = $reportProgress($progress);
+				if (!$running) {
+					throw new ProcessingException('OpenAI/LocalAI task cancelled');
+				}
 				continue;
 			}
 

--- a/lib/TaskProcessing/ReformatParagraphsProvider.php
+++ b/lib/TaskProcessing/ReformatParagraphsProvider.php
@@ -201,7 +201,10 @@ TEXT;
 				$anchors = $this->parseAnchorsFromModelOutput($raw);
 				$result .= $this->insertParagraphBreaksByAnchors($chunk, $anchors);
 				$progress += $increase;
-				$reportProgress($progress);
+				$running = $reportProgress($progress);
+				if (!$running) {
+					throw new ProcessingException('OpenAI/LocalAI task cancelled');
+				}
 				continue;
 			}
 

--- a/lib/TaskProcessing/ReformulateProvider.php
+++ b/lib/TaskProcessing/ReformulateProvider.php
@@ -153,18 +153,24 @@ class ReformulateProvider implements IProvider, ISynchronousOptionsAwareProvider
 							}
 							// we don't report more often than every 250ms
 							if (microtime(true) - $time >= 0.25) {
-								$reportOutput([
+								$running = $reportOutput([
 									'output' => $streamedOutput,
 									'reasoning' => $streamedReasoning,
 								]);
+								if (!$running) {
+									throw new ProcessingException('OpenAI/LocalAI task cancelled');
+								}
 								$time = microtime(true);
 							}
 						}
 						if ($streamedOutput !== '' || $streamedReasoning !== '') {
-							$reportOutput([
+							$running = $reportOutput([
 								'output' => $streamedOutput,
 								'reasoning' => $streamedReasoning,
 							]);
+							if (!$running) {
+								throw new ProcessingException('OpenAI/LocalAI task cancelled');
+							}
 						}
 						$returnValue = $chunks->getReturn();
 						$completion = $returnValue['messages'];

--- a/lib/TaskProcessing/ReformulateProvider.php
+++ b/lib/TaskProcessing/ReformulateProvider.php
@@ -195,7 +195,10 @@ class ReformulateProvider implements IProvider, ISynchronousOptionsAwareProvider
 			if (count($completion) > 0) {
 				$fullOutput .= array_pop($completion);
 				$progress += $increase;
-				$reportProgress($progress);
+				$running = $reportProgress($progress);
+				if (!$running) {
+					throw new ProcessingException('OpenAI/LocalAI task cancelled');
+				}
 				continue;
 			}
 

--- a/lib/TaskProcessing/SummaryProvider.php
+++ b/lib/TaskProcessing/SummaryProvider.php
@@ -122,7 +122,10 @@ class SummaryProvider implements ISynchronousProvider {
 			// Ensure that progress never finishes no matter how many times this loop runs
 			$increase = (1.0 - $progress) / 2.0 / (float)$newNumChunks;
 			$oldNumChunks = $newNumChunks;
-			$reportProgress($progress);
+			$running = $reportProgress($progress);
+			if (!$running) {
+				throw new ProcessingException('OpenAI/LocalAI task cancelled');
+			}
 
 			try {
 				$completions = [];
@@ -134,7 +137,10 @@ class SummaryProvider implements ISynchronousProvider {
 						$completion = $this->openAiAPIService->createChatCompletion($userId, $model, $p, $summarySystemPrompt, null, 1, $maxTokens);
 						$completions[] = $completion['messages'];
 						$progress += $increase;
-						$reportProgress($progress);
+						$running = $reportProgress($progress);
+						if (!$running) {
+							throw new ProcessingException('OpenAI/LocalAI task cancelled');
+						}
 					}
 				} else {
 					$wrapSummaryPrompt = function (string $p): string {
@@ -146,7 +152,10 @@ class SummaryProvider implements ISynchronousProvider {
 					foreach (array_map($wrapSummaryPrompt, $prompts) as $p) {
 						$completions[] = $this->openAiAPIService->createCompletion($userId, $p, 1, $model, $maxTokens);
 						$progress += $increase;
-						$reportProgress($progress);
+						$running = $reportProgress($progress);
+						if (!$running) {
+							throw new ProcessingException('OpenAI/LocalAI task cancelled');
+						}
 					}
 				}
 			} catch (UserFacingProcessingException $e) {

--- a/lib/TaskProcessing/TextToTextChatProvider.php
+++ b/lib/TaskProcessing/TextToTextChatProvider.php
@@ -146,18 +146,24 @@ class TextToTextChatProvider implements IProvider, ISynchronousOptionsAwareProvi
 					}
 					// we don't report more often than every 250ms
 					if (microtime(true) - $time >= 0.25) {
-						$reportOutput([
+						$running = $reportOutput([
 							'output' => $streamedOutput,
 							'reasoning' => $streamedReasoning,
 						]);
+						if (!$running) {
+							throw new ProcessingException('OpenAI/LocalAI task cancelled');
+						}
 						$time = microtime(true);
 					}
 				}
 				if ($streamedOutput !== '' || $streamedReasoning !== '') {
-					$reportOutput([
+					$running = $reportOutput([
 						'output' => $streamedOutput,
 						'reasoning' => $streamedReasoning,
 					]);
+					if (!$running) {
+						throw new ProcessingException('OpenAI/LocalAI task cancelled');
+					}
 				}
 				$returnValue = $chunks->getReturn();
 				$completion = $returnValue['messages'];

--- a/lib/TaskProcessing/TextToTextChatWithToolsProvider.php
+++ b/lib/TaskProcessing/TextToTextChatWithToolsProvider.php
@@ -157,18 +157,24 @@ class TextToTextChatWithToolsProvider implements IProvider, ISynchronousOptionsA
 					}
 					// we don't report more often than every 250ms
 					if (microtime(true) - $time >= 0.25) {
-						$reportOutput([
+						$running = $reportOutput([
 							'output' => $streamedOutput,
 							'reasoning' => $streamedReasoning,
 						]);
+						if (!$running) {
+							throw new ProcessingException('OpenAI/LocalAI task cancelled');
+						}
 						$time = microtime(true);
 					}
 				}
 				if ($streamedOutput !== '' || $streamedReasoning !== '') {
-					$reportOutput([
+					$running = $reportOutput([
 						'output' => $streamedOutput,
 						'reasoning' => $streamedReasoning,
 					]);
+					if (!$running) {
+						throw new ProcessingException('OpenAI/LocalAI task cancelled');
+					}
 				}
 				$returnValue = $chunks->getReturn();
 			} else {

--- a/lib/TaskProcessing/TextToTextProvider.php
+++ b/lib/TaskProcessing/TextToTextProvider.php
@@ -144,18 +144,24 @@ class TextToTextProvider implements IProvider, ISynchronousOptionsAwareProvider 
 						}
 						// we don't report more often than every 250ms
 						if (microtime(true) - $time >= 0.25) {
-							$reportOutput([
+							$running = $reportOutput([
 								'output' => $streamedOutput,
 								'reasoning' => $streamedReasoning,
 							]);
+							if (!$running) {
+								throw new ProcessingException('OpenAI/LocalAI task cancelled');
+							}
 							$time = microtime(true);
 						}
 					}
 					if ($streamedOutput !== '' || $streamedReasoning !== '') {
-						$reportOutput([
+						$running = $reportOutput([
 							'output' => $streamedOutput,
 							'reasoning' => $streamedReasoning,
 						]);
+						if (!$running) {
+							throw new ProcessingException('OpenAI/LocalAI task cancelled');
+						}
 					}
 					$returnValue = $chunks->getReturn();
 					$completion = $returnValue['messages'];

--- a/lib/TaskProcessing/TopicsProvider.php
+++ b/lib/TaskProcessing/TopicsProvider.php
@@ -129,7 +129,10 @@ class TopicsProvider implements ISynchronousProvider {
 			// Ensure that progress never finishes no matter how many times this loop runs
 			$increase = (1.0 - $progress) / (float)$newNumChunks * 0.9;
 			$oldNumChunks = $newNumChunks;
-			$reportProgress($progress);
+			$running = $reportProgress($progress);
+			if (!$running) {
+				throw new ProcessingException('OpenAI/LocalAI task cancelled');
+			}
 
 			try {
 				$completions = [];
@@ -140,7 +143,10 @@ class TopicsProvider implements ISynchronousProvider {
 						$completion = $this->openAiAPIService->createChatCompletion($userId, $model, $p, $topicsSystemPrompt, null, 1, $maxTokens);
 						$completions[] = $completion['messages'];
 						$progress += $increase;
-						$reportProgress($progress);
+						$running = $reportProgress($progress);
+						if (!$running) {
+							throw new ProcessingException('OpenAI/LocalAI task cancelled');
+						}
 					}
 				} else {
 					$wrapTopicsPrompt = function (string $p): string {
@@ -151,7 +157,10 @@ class TopicsProvider implements ISynchronousProvider {
 					foreach (array_map($wrapTopicsPrompt, $prompts) as $p) {
 						$completions[] = $this->openAiAPIService->createCompletion($userId, $p, 1, $model, $maxTokens);
 						$progress += $increase;
-						$reportProgress($progress);
+						$running = $reportProgress($progress);
+						if (!$running) {
+							throw new ProcessingException('OpenAI/LocalAI task cancelled');
+						}
 					}
 				}
 			} catch (UserFacingProcessingException $e) {

--- a/lib/TaskProcessing/TranslateProvider.php
+++ b/lib/TaskProcessing/TranslateProvider.php
@@ -142,9 +142,12 @@ class TranslateProvider implements IProvider, ISynchronousOptionsAwareProvider {
 
 		try {
 			$reportTranslationOutput = function (string $translationOutput) use ($reportOutput) {
-				$reportOutput([
+				$running = $reportOutput([
 					'output' => $translationOutput,
 				]);
+				if (!$running) {
+					throw new ProcessingException('OpenAI/LocalAI task cancelled');
+				}
 			};
 			$translation = $this->translateService->translate(
 				$inputText, $input['origin_language'] ?? '', $input['target_language'] ?? '',

--- a/tests/unit/Providers/OpenAiProviderTest.php
+++ b/tests/unit/Providers/OpenAiProviderTest.php
@@ -182,7 +182,7 @@ class OpenAiProviderTest extends TestCase {
 
 		$this->iClient->expects($this->once())->method('post')->with($url, $options)->willReturn($iResponse);
 
-		$result = $freePromptProvider->process(self::TEST_USER1, ['input' => $prompt], fn () => null, new SynchronousProviderOptions(preferStreaming: false));
+		$result = $freePromptProvider->process(self::TEST_USER1, ['input' => $prompt], fn () => true, new SynchronousProviderOptions(preferStreaming: false));
 		$this->assertEquals('This is a test response.', $result['output']);
 
 		// Check that token usage is logged properly
@@ -355,7 +355,7 @@ class OpenAiProviderTest extends TestCase {
 
 		$this->iClient->expects($this->once())->method('post')->with($url, $options)->willReturn($iResponse);
 
-		$result = $emojiProvider->process(self::TEST_USER1, ['input' => $prompt], fn () => null);
+		$result = $emojiProvider->process(self::TEST_USER1, ['input' => $prompt], fn () => true);
 		$this->assertEquals('This is a test response.', $result['output']);
 
 		// Check that token usage is logged properly
@@ -419,7 +419,7 @@ class OpenAiProviderTest extends TestCase {
 
 		$this->iClient->expects($this->once())->method('post')->with($url, $options)->willReturn($iResponse);
 
-		$result = $headlineProvider->process(self::TEST_USER1, ['input' => $prompt], fn () => null);
+		$result = $headlineProvider->process(self::TEST_USER1, ['input' => $prompt], fn () => true);
 		$this->assertEquals('This is a test response.', $result['output']);
 
 		// Check that token usage is logged properly
@@ -485,7 +485,7 @@ class OpenAiProviderTest extends TestCase {
 
 		$this->iClient->expects($this->once())->method('post')->with($url, $options)->willReturn($iResponse);
 
-		$result = $changeToneProvider->process(self::TEST_USER1, ['input' => $textInput, 'tone' => $toneInput ], fn () => null, new SynchronousProviderOptions(preferStreaming: false));
+		$result = $changeToneProvider->process(self::TEST_USER1, ['input' => $textInput, 'tone' => $toneInput ], fn () => true, new SynchronousProviderOptions(preferStreaming: false));
 		$this->assertEquals('This is a test response.', $result['output']);
 
 		// Check that token usage is logged properly
@@ -554,7 +554,7 @@ class OpenAiProviderTest extends TestCase {
 
 		$this->iClient->expects($this->once())->method('post')->with($url, $options)->willReturn($iResponse);
 
-		$result = $summaryProvider->process(self::TEST_USER1, ['input' => $prompt], fn () => null);
+		$result = $summaryProvider->process(self::TEST_USER1, ['input' => $prompt], fn () => true);
 		$this->assertEquals('This is a test response.', $result['output']);
 
 		// Check that token usage is logged properly
@@ -622,7 +622,7 @@ class OpenAiProviderTest extends TestCase {
 
 		$this->iClient->expects($this->once())->method('post')->with($url, $options)->willReturn($iResponse);
 
-		$result = $proofreadProvider->process(self::TEST_USER1, ['input' => $prompt], fn () => null);
+		$result = $proofreadProvider->process(self::TEST_USER1, ['input' => $prompt], fn () => true);
 		$this->assertEquals('This is a test response.', $result['output']);
 
 		// Check that token usage is logged properly
@@ -702,7 +702,7 @@ class OpenAiProviderTest extends TestCase {
 			}),
 		)->willReturn($iResponse);
 
-		$result = $translationProvider->process(self::TEST_USER1, ['input' => $inputText, 'origin_language' => $fromLang, 'target_language' => $toLang], fn () => null, new SynchronousProviderOptions(preferStreaming: false));
+		$result = $translationProvider->process(self::TEST_USER1, ['input' => $inputText, 'origin_language' => $fromLang, 'target_language' => $toLang], fn () => true, new SynchronousProviderOptions(preferStreaming: false));
 		$this->assertEquals(['output' => $aiContent['translation']], $result);
 
 		// Check that token usage is logged properly
@@ -811,7 +811,7 @@ class OpenAiProviderTest extends TestCase {
 				'origin_language' => $fromLang,
 				'target_language' => $toLang,
 			],
-			fn () => null,
+			fn () => true,
 			new SynchronousProviderOptions(includeWatermarks: false, preferStreaming: false),
 		);
 
@@ -862,7 +862,7 @@ class OpenAiProviderTest extends TestCase {
 
 		$this->iClient->expects($this->once())->method('post')->with($url, $options)->willReturn($iResponse);
 
-		$result = $TTSProvider->process(self::TEST_USER1, ['input' => $inputText], fn () => null);
+		$result = $TTSProvider->process(self::TEST_USER1, ['input' => $inputText], fn () => true);
 		$this->assertArrayHasKey('speech', $result);
 
 		// Check that token usage is logged properly (should be 21 characters)
@@ -916,7 +916,7 @@ class OpenAiProviderTest extends TestCase {
 
 		$this->iClient->expects($this->once())->method('post')->with($url, $options)->willReturn($iResponse);
 
-		$result = $TextToImageProvider->process(self::TEST_USER1, ['input' => $inputText, 'numberOfImages' => 1], fn () => null);
+		$result = $TextToImageProvider->process(self::TEST_USER1, ['input' => $inputText, 'numberOfImages' => 1], fn () => true);
 		$this->assertArrayHasKey('images', $result);
 		$this->assertArrayHasKey(0, $result['images']);
 
@@ -1002,7 +1002,7 @@ TEXT;
 
 		$this->iClient->expects($this->once())->method('post')->with($url, $options)->willReturn($iResponse);
 
-		$result = $provider->process(self::TEST_USER1, ['input' => $inputText], fn () => null);
+		$result = $provider->process(self::TEST_USER1, ['input' => $inputText], fn () => true);
 		$this->assertEquals("Alpha part.\n\nBeta part.", $result['output']);
 
 		$usage = $this->quotaUsageMapper->getQuotaUnitsOfUser(self::TEST_USER1, Application::QUOTA_TYPE_TEXT);


### PR DESCRIPTION
Use the return value of reportOutput and reportProgress to early exit the provider's process methods when a task has been cancelled.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
