### PR TITLE
Fix on some instances EntityType not being found

### DIFF
--- a/lib/Db/EntityType.php
+++ b/lib/Db/EntityType.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\OpenAi\Db;
+
+enum EntityType: int {
+	case USER = 0;
+	case GROUP = 1;
+}

--- a/lib/Db/QuotaUserMapper.php
+++ b/lib/Db/QuotaUserMapper.php
@@ -12,11 +12,6 @@ use OCP\DB\Exception;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 
-enum EntityType: int {
-	case USER = 0;
-	case GROUP = 1;
-}
-
 /**
  * @extends QBMapper<QuotaUser>
  */


### PR DESCRIPTION
Fixes error that happens on production instances when a QuotaRule is created/updated:
```
Class "OCA\OpenAi\Db\EntityType" not found in file '/var/www/html/custom_apps/integration_openai/lib/Service/QuotaRuleService.php' line 184
```

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
