### PR TITLE
docs: add Eden AI to the list of OpenAI-compatible services

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ They might work when connecting to other services, without any guarantee.
 
 Instead of connecting to the OpenAI API for these, you can also connect to a self-hosted [LocalAI](https://localai.io) instance or [Ollama](https://ollama.com/) instance
 or to any service that implements an API similar to the OpenAI one, for example:
-[IONOS AI Model Hub](https://docs.ionos.com/cloud/ai/ai-model-hub), [Plusserver](https://www.plusserver.com/en/ai-platform/) or [MistralAI](https://mistral.ai).  
+[IONOS AI Model Hub](https://docs.ionos.com/cloud/ai/ai-model-hub), [Plusserver](https://www.plusserver.com/en/ai-platform/), [MistralAI](https://mistral.ai) or [Eden AI](https://www.edenai.co/).  
 Make sure to use the OpenAI-compatible endpoint instead of the custom ones they provide.
 
 :warning: This app is mainly tested with OpenAI. We do not guarantee it works perfectly


### PR DESCRIPTION
## Summary

Adds **Eden AI** to the README list of services that expose an OpenAI-compatible API (alongside IONOS AI Model Hub, Plusserver and MistralAI).

[Eden AI](https://www.edenai.co/) is an EU-based, GDPR-compliant unified API. Its OpenAI-compatible endpoint works with `integration_openai` out of the box:

- Service URL: `https://api.edenai.run/v3`
- `GET /v3/models` returns an OpenAI-style list (verified: `{"object":"list","data":[...]}`, 760 models, including `@eu` regional variants)
- `POST /v3/chat/completions` works with the standard OpenAI schema

This is a docs-only change (one line), no code changes. Commit is DCO signed-off.
