### PR TITLE
fix: openrouter filters out non llm models by default

### DIFF
--- a/lib/Service/OpenAiAPIService.php
+++ b/lib/Service/OpenAiAPIService.php
@@ -93,6 +93,26 @@ class OpenAiAPIService {
 
 	/**
 	 * @param ?string $serviceType
+	 * @return bool
+	 */
+	public function isUsingOpenRouter(?string $serviceType = null): bool {
+		$serviceUrl = '';
+		if ($serviceType === Application::SERVICE_TYPE_IMAGE) {
+			$serviceUrl = $this->openAiSettingsService->getImageServiceUrl();
+		} elseif ($serviceType === Application::SERVICE_TYPE_STT) {
+			$serviceUrl = $this->openAiSettingsService->getSttServiceUrl();
+		} elseif ($serviceType === Application::SERVICE_TYPE_TTS) {
+			$serviceUrl = $this->openAiSettingsService->getTtsServiceUrl();
+		}
+		if ($serviceUrl === '') {
+			$serviceUrl = $this->openAiSettingsService->getServiceUrl();
+		}
+		// Return true if the service URL references OpenRouter (e.g., openrouter.ai)
+		return str_starts_with(strtolower($serviceUrl), 'https://openrouter.ai');
+	}
+
+	/**
+	 * @param ?string $serviceType
 	 *
 	 * @return string
 	 */
@@ -221,7 +241,8 @@ class OpenAiAPIService {
 
 		try {
 			$this->logger->debug('Actually getting OpenAI models with a network request');
-			$modelsResponse = $this->request($userId, 'models', serviceType: $serviceType);
+			$params = $this->isUsingOpenRouter($serviceType) ? ['output_modalities' => 'all'] : [];
+			$modelsResponse = $this->request($userId, 'models', $params, serviceType: $serviceType);
 		} catch (Exception $e) {
 			$this->logger->warning('Error retrieving models (exc): ' . $e->getMessage());
 			throw $e;


### PR DESCRIPTION
Noticed that openrouter filters models by modalities (https://openrouter.ai/docs/guides/overview/models#output_modalities) this could actually be useful for only showing the right image, tts, etc models, but sadly seems to only be openrouter specific.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
