### PR TITLE
chore: Prepare 4.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [4.5.2] - 2026-07-27
+
+### Fixed
+
+- Fix on some instances EntityType not being found @lukasdotcom [#393](https://github.com/nextcloud/integration_openai/pull/393)
+- Fix: openrouter filters out non llm models by default @lukasdotcom [#404](https://github.com/nextcloud/integration_openai/pull/404)
+- Fix: mistral passes references when tool calls are used @lukasdotcom [#409](https://github.com/nextcloud/integration_openai/pull/409)
+
 ## [4.5.1] - 2026-05-22
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -101,7 +101,7 @@ Negative:
 
 Learn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud.com/blog/nextcloud-ethical-ai-rating/).
 ]]>	</description>
-	<version>4.5.1</version>
+	<version>4.5.2</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>OpenAi</namespace>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "integration_openai",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "integration_openai",
-      "version": "4.5.1",
+      "version": "4.5.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integration_openai",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "description": "OpenAI integration",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
## [4.5.2] - 2026-07-27

### Fixed

- Fix on some instances EntityType not being found @lukasdotcom [#393](https://github.com/nextcloud/integration_openai/pull/393)
- Fix: openrouter filters out non llm models by default @lukasdotcom [#404](https://github.com/nextcloud/integration_openai/pull/404)
- Fix: mistral passes references when tool calls are used @lukasdotcom [#409](https://github.com/nextcloud/integration_openai/pull/409)