### PR TITLE
Feat/configurable summary system prompts

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -64,6 +64,9 @@ class Application extends App implements IBootstrap {
 	public const DEFAULT_QUOTA_PERIOD = 30;
 	public const DEFAULT_QUOTA_CONFIG = ['length' => self::DEFAULT_QUOTA_PERIOD, 'unit' => 'day', 'day' => 1];
 
+	public const DEFAULT_SUMMARY_SYSTEM_PROMPT = 'You are a helpful assistant that summarizes text in the same language as the text. '
+				. 'You should only return the summary without any additional information. ';
+
 	public const DEFAULT_OPENAI_TEXT_GENERATION_TIME = 10; // seconds
 	public const DEFAULT_LOCALAI_TEXT_GENERATION_TIME = 60; // seconds
 	public const DEFAULT_OPENAI_IMAGE_GENERATION_TIME = 20; // seconds

--- a/lib/Service/OpenAiSettingsService.php
+++ b/lib/Service/OpenAiSettingsService.php
@@ -319,6 +319,13 @@ class OpenAiSettingsService {
 	}
 
 	/**
+	 * @return string
+	 */
+	public function getSummarySystemPrompt(): string {
+		return $this->appConfig->getValueString(Application::APP_ID, 'system_prompt_summary', Application::DEFAULT_SUMMARY_SYSTEM_PROMPT, lazy: true) ?: Application::DEFAULT_SUMMARY_SYSTEM_PROMPT;
+	}
+
+	/**
 	 * @return int[]
 	 */
 	public function getQuotas(): array {

--- a/lib/Service/OpenAiSettingsService.php
+++ b/lib/Service/OpenAiSettingsService.php
@@ -326,6 +326,13 @@ class OpenAiSettingsService {
 	}
 
 	/**
+	 * @return string
+	 */
+	public function getTalkSummarySystemPrompt(): string {
+		return $this->appConfig->getValueString(Application::APP_ID, 'system_prompt_talk_summary', Application::DEFAULT_SUMMARY_SYSTEM_PROMPT, lazy: true) ?: Application::DEFAULT_SUMMARY_SYSTEM_PROMPT;
+	}
+
+	/**
 	 * @return int[]
 	 */
 	public function getQuotas(): array {

--- a/lib/TaskProcessing/SummaryProvider.php
+++ b/lib/TaskProcessing/SummaryProvider.php
@@ -79,6 +79,11 @@ class SummaryProvider implements ISynchronousProvider {
 				$this->l->t('The model used to generate the completion'),
 				EShapeType::Enum
 			),
+			'talk_meeting' => new ShapeDescriptor(
+				$this->l->t("Talk meeting flag"),
+				$this->l->t('Flag that indicates if the summary is generated from a Talk meeting recording.'),
+				EShapeType::Number
+			),
 		];
 	}
 
@@ -106,6 +111,7 @@ class SummaryProvider implements ISynchronousProvider {
 			'model' => $adminModel,
 			'format' => 'auto',
 			'complexity' => 'medium',
+			'talk_meeting' => 0,
 		];
 	}
 
@@ -139,6 +145,7 @@ class SummaryProvider implements ISynchronousProvider {
 			$model = $input['model'];
 		}
 
+		$isTalkMeeting = (bool)($input['talk_meeting'] ?? 0);
 		$prompts = $this->chunkService->chunkSplitPrompt($prompt);
 		$newNumChunks = count($prompts);
 		$progress = 0.0;
@@ -153,7 +160,11 @@ class SummaryProvider implements ISynchronousProvider {
 
 			try {
 				$completions = [];
-				$summarySystemPrompt = $this->openAiSettingsService->getSummarySystemPrompt();
+				if ($isTalkMeeting) {
+					$summarySystemPrompt = $this->openAiSettingsService->getTalkSummarySystemPrompt();
+				} else {
+					$summarySystemPrompt = $this->openAiSettingsService->getSummarySystemPrompt();
+				}
 				if (isset($input['format'])) {
 					if ($input['format'] === 'paragraph') {
 						$summarySystemPrompt .= 'Return the summary as a paragraph. ';

--- a/lib/TaskProcessing/SummaryProvider.php
+++ b/lib/TaskProcessing/SummaryProvider.php
@@ -153,8 +153,7 @@ class SummaryProvider implements ISynchronousProvider {
 
 			try {
 				$completions = [];
-				$summarySystemPrompt = 'You are a helpful assistant that summarizes text in the same language as the text. '
-					. 'You should only return the summary without any additional information. ';
+				$summarySystemPrompt = $this->openAiSettingsService->getSummarySystemPrompt();
 				if (isset($input['format'])) {
 					if ($input['format'] === 'paragraph') {
 						$summarySystemPrompt .= 'Return the summary as a paragraph. ';

--- a/tests/unit/Providers/OpenAiProviderTest.php
+++ b/tests/unit/Providers/OpenAiProviderTest.php
@@ -656,6 +656,88 @@ class OpenAiProviderTest extends TestCase {
 		}
 	}
 
+	public function testSummaryProviderConfigurableTalkSystemPrompt(): void {
+		try {
+			$configurableSystemPrompt = 'Configurable Talk summary system prompt from app config';
+			$appConfig = \OCP\Server::get(IAppConfig::class);
+			$appConfig->setValueString(
+				Application::APP_ID,
+				'system_prompt_talk_summary',
+				$configurableSystemPrompt,
+			);
+
+			$summaryProvider = new SummaryProvider(
+				$this->openAiApiService,
+				$this->openAiSettingsService,
+				$this->createMock(\OCP\IL10N::class),
+				$this->chunkService,
+				self::TEST_USER1,
+			);
+
+			$prompt = 'This is a test prompt';
+			$n = 1;
+
+			$response = '{
+				"id": "chatcmpl-123",
+				"object": "chat.completion",
+				"created": 1677652288,
+				"model": "gpt-3.5-turbo-0613",
+				"system_fingerprint": "fp_44709d6fcb",
+				"choices": [
+				{
+					"index": 0,
+					"message": {
+					"role": "assistant",
+					"content": "This is a test response."
+					},
+					"finish_reason": "stop"
+				}
+				],
+				"usage": {
+				"prompt_tokens": 9,
+				"completion_tokens": 12,
+				"total_tokens": 21
+				}
+			}';
+
+			$url = self::OPENAI_API_BASE . 'chat/completions';
+
+			$options = ['timeout' => Application::OPENAI_DEFAULT_REQUEST_TIMEOUT, 'headers' => ['User-Agent' => Application::USER_AGENT, 'Authorization' => self::AUTHORIZATION_HEADER, 'Content-Type' => 'application/json']];
+			$options['body'] = json_encode([
+				'model' => Application::DEFAULT_COMPLETION_MODEL_ID,
+				'messages' => [
+					['role' => 'system', 'content' => $configurableSystemPrompt],
+					['role' => 'user', 'content' => $prompt],
+				],
+				'n' => $n,
+				'stream' => false,
+				'max_completion_tokens' => Application::DEFAULT_MAX_NUM_OF_TOKENS,
+				'user' => self::TEST_USER1,
+			]);
+
+			$iResponse = $this->createMock(\OCP\Http\Client\IResponse::class);
+			$iResponse->method('getBody')->willReturn($response);
+			$iResponse->method('getStatusCode')->willReturn(200);
+			$iResponse->method('getHeader')->with('Content-Type')->willReturn('application/json');
+
+			$this->iClient->expects($this->once())->method('post')->with($url, $options)->willReturn($iResponse);
+
+			$result = $summaryProvider->process(self::TEST_USER1, ['input' => $prompt, 'talk_meeting' => 1], fn () => true);
+			$this->assertEquals('This is a test response.', $result['output']);
+
+			// Check that token usage is logged properly
+			$usage = $this->quotaUsageMapper->getQuotaUnitsOfUser(self::TEST_USER1, Application::QUOTA_TYPE_TEXT);
+			$this->assertEquals(21, $usage);
+			// Clear quota usage
+			$this->quotaUsageMapper->deleteUserQuotaUsages(self::TEST_USER1);
+		} finally {
+			$appConfig->deleteKey(
+				Application::APP_ID,
+				'system_prompt_talk_summary'
+			);
+		}
+	}
+
 	public function testProofreadProvider(): void {
 		$proofreadProvider = new ProofreadProvider(
 			$this->openAiApiService,

--- a/tests/unit/Providers/OpenAiProviderTest.php
+++ b/tests/unit/Providers/OpenAiProviderTest.php
@@ -574,6 +574,88 @@ class OpenAiProviderTest extends TestCase {
 		$this->quotaUsageMapper->deleteUserQuotaUsages(self::TEST_USER1);
 	}
 
+	public function testSummaryProviderConfigurableSystemPrompt(): void {
+		try {
+			$configurableSystemPrompt = 'Configurable summary system prompt from app config';
+			$appConfig = \OCP\Server::get(IAppConfig::class);
+			$appConfig->setValueString(
+				Application::APP_ID,
+				'system_prompt_summary',
+				$configurableSystemPrompt,
+			);
+
+			$summaryProvider = new SummaryProvider(
+				$this->openAiApiService,
+				$this->openAiSettingsService,
+				$this->createMock(\OCP\IL10N::class),
+				$this->chunkService,
+				self::TEST_USER1,
+			);
+
+			$prompt = 'This is a test prompt';
+			$n = 1;
+
+			$response = '{
+				"id": "chatcmpl-123",
+				"object": "chat.completion",
+				"created": 1677652288,
+				"model": "gpt-3.5-turbo-0613",
+				"system_fingerprint": "fp_44709d6fcb",
+				"choices": [
+				{
+					"index": 0,
+					"message": {
+					"role": "assistant",
+					"content": "This is a test response."
+					},
+					"finish_reason": "stop"
+				}
+				],
+				"usage": {
+				"prompt_tokens": 9,
+				"completion_tokens": 12,
+				"total_tokens": 21
+				}
+			}';
+
+			$url = self::OPENAI_API_BASE . 'chat/completions';
+
+			$options = ['timeout' => Application::OPENAI_DEFAULT_REQUEST_TIMEOUT, 'headers' => ['User-Agent' => Application::USER_AGENT, 'Authorization' => self::AUTHORIZATION_HEADER, 'Content-Type' => 'application/json']];
+			$options['body'] = json_encode([
+				'model' => Application::DEFAULT_COMPLETION_MODEL_ID,
+				'messages' => [
+					['role' => 'system', 'content' => $configurableSystemPrompt],
+					['role' => 'user', 'content' => $prompt],
+				],
+				'n' => $n,
+				'stream' => false,
+				'max_completion_tokens' => Application::DEFAULT_MAX_NUM_OF_TOKENS,
+				'user' => self::TEST_USER1,
+			]);
+
+			$iResponse = $this->createMock(\OCP\Http\Client\IResponse::class);
+			$iResponse->method('getBody')->willReturn($response);
+			$iResponse->method('getStatusCode')->willReturn(200);
+			$iResponse->method('getHeader')->with('Content-Type')->willReturn('application/json');
+
+			$this->iClient->expects($this->once())->method('post')->with($url, $options)->willReturn($iResponse);
+
+			$result = $summaryProvider->process(self::TEST_USER1, ['input' => $prompt], fn () => true);
+			$this->assertEquals('This is a test response.', $result['output']);
+
+			// Check that token usage is logged properly
+			$usage = $this->quotaUsageMapper->getQuotaUnitsOfUser(self::TEST_USER1, Application::QUOTA_TYPE_TEXT);
+			$this->assertEquals(21, $usage);
+			// Clear quota usage
+			$this->quotaUsageMapper->deleteUserQuotaUsages(self::TEST_USER1);
+		} finally {
+			$appConfig->deleteKey(
+				Application::APP_ID,
+				'system_prompt_summary'
+			);
+		}
+	}
+
 	public function testProofreadProvider(): void {
 		$proofreadProvider = new ProofreadProvider(
 			$this->openAiApiService,


### PR DESCRIPTION
# Configurable system prompts for summary tasks

This PR adds a functionality for Summary Provider to define custom system prompt and distinguish them based on two cases:
- simple summary in Nextcloud Assistant UI (summary of docs, articles etc)
- meeting specific summary for Talk recordings (purpose of the meeting, participants, arrangements etc)

Those summaries have different context, so different model's instructions are needed

### How to provide system prompts?

I created two additional functions to read a value from from config keys. In this case: `system_prompt_summary` and `system_prompt_talk_summary`. To set those values you have to use `occ` command:
```
php occ config:app:set integration_openai system_prompt_summary --value="Configurable summary system prompt"
```
and

```
`php occ config:app:set integration_openai system_prompt_talk_summary --value="Configurable talk summary system prompt"`
```

If the value of the configurable system prompt is empty string `""` or there is no key `system_prompt_summary`/`system_prompt_talk_summary`, a system prompt for summary will have default value. 
Default value is a value of the `summarySystemPrompt` before my changes: `You are a helpful assistant that summarizes text in the same language as the text. You should only return the summary without any additional information. `

### Distinguish if a summary is for a Talk meeting

The idea is to pass a flag `'talk_meeting'` that equals to 1 in an array passed in [Task](https://github.com/nextcloud/spreed/blob/v24.0.0/lib/Service/RecordingService.php#L273) object. Default value in this PR sets it to 0: `'talk_meeting' => 0`. I am going to make a PR to nextcloud [spreed](https://github.com/nextcloud/spreed) repo as well.

### Naming convention

Names of the keys that are used to set prompts are similar to naming convention in Summary Provider that was ealier introduced- `summarySystemPrompt`. I start with a prefix `system_prompt` because I think it is good idea to provide configurable system prompts for other tasks as well, for example translation. It will be easier to read config:app if system_prompts will be written one above/belowe another (keys are sorted).

### Tests

- `testSummaryProvider` - tests default functionality (no system prompt set using `occ`) of the changes. It ensures that the default summary system prompt is the same as it was before my changes
- `testSummaryProviderConfigurableSystemPrompt` - tests if configurable system prompt works. I set key `system_prompt_summary` value and delete it even if the test fails
- `testSummaryProviderConfigurableTalkSystemPrompt` - the same as the above + I pass `'talk_meeting'` flag in the request


### Question for devs

I am currently running nc34 and `integration_openai` version `4.5.2`. Where should I also make PR to have configurable system prompts in my case?

### Additional PR (spreed)

After review/changes I will make PR to [spreed](https://github.com/nextcloud/spreed) repo to enable passing a flag `'talk_meeting'`.

### Thoughts

I am aware of additional instructions for LLM  that are set by assigning a value to `format` and `complexity`. It affects model output but it is still pretty much hard-coded. The main issue is that there is no possibility to have specific instruction for a specific context of summary task. In this case - call meeting on Talk (summary from a transcript). Sample output format:
```
1. Meeting purpose (sentence)
The purpose of a meeting ...
2. Time and place (sentence)
 ...
3. Participants (bullet points)
- Name Surname - works in IT department
- ...
4. Arrangements (bullet points)
- person X has to do Y
- ...
```
Configurable system prompt will provide a possibility to customize the output freely.

I am also aware that devs have a vision for Summary Provider and its output by using specific instructions for:
- `format` - auto, sentence, paragraph, bullet_points
- `complexity` - simple, medium, complex
The output format is controlled in some way. Changes in this PR give full control to the admin of nextcloud instance. 

I see the potential conflict between changes that I introduced in this PR and existing intended way to influence the output in specific, controlled way (`format`, `complexity`). I am open to changing and adjusting the implementation and hope we could work something out.








