### PR TITLE
feat: support rtf and parse pdf to text when documents not supported natively

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,9 @@
 		"php": "^8.2 || ^8.3 || ^8.4",
 		"bamarni/composer-bin-plugin": "^1.8",
 		"fileeye/pel": "^0.12.0",
-		"james-heinrich/getid3": "^1.9"
+		"james-heinrich/getid3": "^1.9",
+		"smalot/pdfparser": "^2.12",
+		"henck/rtf-to-html": "^1.3"
 	},
 	"scripts": {
 		"lint": "find . -name \\*.php -not -path './vendor*' -print0 | xargs -0 -n1 php -l",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "db059d652920a0c6cd9c7afda5199a69",
+    "content-hash": "a5eca537c96be146e2d7649962da0b07",
     "packages": [
         {
             "name": "bamarni/composer-bin-plugin",
@@ -126,6 +126,53 @@
             "time": "2026-03-19T18:27:55+00:00"
         },
         {
+            "name": "henck/rtf-to-html",
+            "version": "1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/henck/rtf-html-php.git",
+                "reference": "36e4cdcc78d6b4f7075522c93fc41547a0faffe7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/henck/rtf-html-php/zipball/36e4cdcc78d6b4f7075522c93fc41547a0faffe7",
+                "reference": "36e4cdcc78d6b4f7075522c93fc41547a0faffe7",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "RtfHtmlPhp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alexander van Oostenrijk",
+                    "email": "alex.vanoostenrijk@gmail.com"
+                }
+            ],
+            "description": "RTF to HTML converter in PHP",
+            "keywords": [
+                "converter",
+                "rtf"
+            ],
+            "support": {
+                "issues": "https://github.com/henck/rtf-html-php/issues",
+                "source": "https://github.com/henck/rtf-html-php/tree/v1.3"
+            },
+            "time": "2026-03-10T18:58:29+00:00"
+        },
+        {
             "name": "james-heinrich/getid3",
             "version": "v1.9.25",
             "source": {
@@ -191,6 +238,142 @@
                 "source": "https://github.com/JamesHeinrich/getID3/tree/v1.9.25"
             },
             "time": "2026-03-10T11:56:47+00:00"
+        },
+        {
+            "name": "smalot/pdfparser",
+            "version": "v2.12.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/smalot/pdfparser.git",
+                "reference": "2cfa0d92bd557875c9f52a75fde0e8392302a354"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/smalot/pdfparser/zipball/2cfa0d92bd557875c9f52a75fde0e8392302a354",
+                "reference": "2cfa0d92bd557875c9f52a75fde0e8392302a354",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "ext-zlib": "*",
+                "php": ">=7.1",
+                "symfony/polyfill-mbstring": "^1.18"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Smalot\\PdfParser\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastien MALOT",
+                    "email": "sebastien@malot.fr"
+                }
+            ],
+            "description": "Pdf parser library. Can read and extract information from pdf file.",
+            "homepage": "https://www.pdfparser.org",
+            "keywords": [
+                "extract",
+                "parse",
+                "parser",
+                "pdf",
+                "text"
+            ],
+            "support": {
+                "issues": "https://github.com/smalot/pdfparser/issues",
+                "source": "https://github.com/smalot/pdfparser/tree/v2.12.5"
+            },
+            "time": "2026-04-17T11:37:58+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.38.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-27T06:59:30+00:00"
         }
     ],
     "packages-dev": [

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -178,17 +178,25 @@ class Application extends App implements IBootstrap {
 	}
 
 	public function boot(IBootContext $context): void {
-		// Load PHP Exif Library for adding image metadata
-		\spl_autoload_register(function ($class) {
-			if (\substr_compare($class, 'OCA\OpenAi\Vendor\lsolesen\\pel\\', 0, 13) === 0) {
-				$classname = \str_replace('OCA\\OpenAi\\Vendor\\lsolesen\\pel\\', '', $class);
-				$load = \realpath(__DIR__ . '/../../vendor/fileeye/pel/src/' . $classname . '.php');
-				if ($load !== \false) {
-					include_once \realpath($load);
+		$vendorDir = __DIR__ . '/../../vendor';
+		\spl_autoload_register(function (string $class) use ($vendorDir) {
+			$prefixes = [
+				'OCA\\OpenAi\\Vendor\\lsolesen\\pel\\' => $vendorDir . '/fileeye/pel/src/',
+				'OCA\\OpenAi\\Vendor\\RtfHtmlPhp\\' => $vendorDir . '/henck/rtf-to-html/src/',
+				'OCA\\OpenAi\\Vendor\\Smalot\\PdfParser\\' => $vendorDir . '/smalot/pdfparser/src/Smalot/PdfParser/',
+			];
+			foreach ($prefixes as $prefix => $baseDir) {
+				if (!str_starts_with($class, $prefix)) {
+					continue;
 				}
+				$file = $baseDir . str_replace('\\', '/', substr($class, strlen($prefix))) . '.php';
+				if (is_file($file)) {
+					include_once $file;
+				}
+				return;
 			}
 		});
 		// Load getID3 library for adding audio metadata
-		require_once(__DIR__ . '/../../vendor/james-heinrich/getid3/getid3/getid3.php');
+		require_once($vendorDir . '/james-heinrich/getid3/getid3/getid3.php');
 	}
 }

--- a/lib/Service/OpenAiFileService.php
+++ b/lib/Service/OpenAiFileService.php
@@ -10,12 +10,16 @@ declare(strict_types=1);
 namespace OCA\OpenAi\Service;
 
 use OCA\OpenAi\AppInfo\Application;
+use OCA\OpenAi\Vendor\RtfHtmlPhp\Document;
+use OCA\OpenAi\Vendor\RtfHtmlPhp\Html\HtmlFormatter;
+use OCA\OpenAi\Vendor\Smalot\PdfParser\Parser;
 use OCP\Files\File;
 use OCP\Files\IRootFolder;
 use OCP\IL10N;
 use OCP\TaskProcessing\Exception\ProcessingException;
 use OCP\TaskProcessing\Exception\UserFacingProcessingException;
 use OCP\TaskProcessing\IManager as ITaskProcessingManager;
+use Psr\Log\LoggerInterface;
 
 class OpenAiFileService {
 	private const MAX_FILE_SIZE_BYTES = 50_000_000;
@@ -71,6 +75,7 @@ class OpenAiFileService {
 		private OpenAiSettingsService $openAiSettingsService,
 		private IRootFolder $rootFolder,
 		private ITaskProcessingManager $taskProcessingManager,
+		private LoggerInterface $logger,
 	) {
 	}
 
@@ -143,6 +148,8 @@ class OpenAiFileService {
 			return $this->buildVideoContent($file, $fileType);
 		} elseif ($fileType === 'application/pdf') {
 			return $this->buildDocumentContent($file, $fileType);
+		} elseif ($fileType === 'text/rtf') {
+			return $this->buildRtfContent($file);
 		} else {
 			return $this->buildTextContent($file, $fileType);
 		}
@@ -228,16 +235,18 @@ class OpenAiFileService {
 	}
 
 	/**
-	 * @return list<array{type: string, file: array{filename: string, file_data: string}}>
+	 * @return list<array{type: string, text: string}|array{type: string, file: array{filename: string, file_data: string}}>
 	 */
 	private function buildDocumentContent(File $file, string $fileType): array {
 		if (!$this->openAiSettingsService->getMultimodalDocumentEnabled()) {
-			throw new UserFacingProcessingException(
-				'Document attachments are disabled',
-				0,
-				null,
-				$this->l10n->t('Document attachments are unsupported.'),
-			);
+			$this->logger->info('Falling back to extracting text from pdf for file', ['fileId' => $file->getId()]);
+			$parser = new Parser();
+			$pdf = $parser->parseContent(stream_get_contents($file->fopen('rb')));
+			$text = $pdf->getText();
+			return [[
+				'type' => 'text',
+				'text' => 'Filename:' . $file->getName() . "\nContent:\n" . $text,
+			]];
 		}
 		return [[
 			'type' => 'file',
@@ -245,6 +254,19 @@ class OpenAiFileService {
 				'filename' => $file->getName(),
 				'file_data' => 'data:' . $fileType . ';base64,' . base64_encode(stream_get_contents($file->fopen('rb'))),
 			],
+		]];
+	}
+
+	/**
+	 * @return list<array{type: string, text: string}>
+	 */
+	private function buildRtfContent(File $file): array {
+		$document = new Document(stream_get_contents($file->fopen('rb')));
+		$formatter = new HtmlFormatter('UTF-8');
+		$html = $formatter->Format($document);
+		return [[
+			'type' => 'text',
+			'text' => 'Filename:' . $file->getName() . "\nContent:\n" . $html,
 		]];
 	}
 

--- a/psalm.xml
+++ b/psalm.xml
@@ -55,11 +55,5 @@
 				<referencedClass name="OCP\TaskProcessing\TaskTypes\AudioToTextSubtitles" />
 			</errorLevel>
 		</UndefinedClass>
-		<UndefinedDocblockClass>
-			<errorLevel type="suppress">
-				<referencedClass name="Doctrine\DBAL\Schema\Table" />
-				<referencedClass name="Doctrine\DBAL\Schema\Schema" />
-			</errorLevel>
-		</UndefinedDocblockClass>
 	</issueHandlers>
 </psalm>

--- a/tests/unit/Providers/OpenAiProviderTest.php
+++ b/tests/unit/Providers/OpenAiProviderTest.php
@@ -103,6 +103,7 @@ class OpenAiProviderTest extends TestCase {
 				$this->openAiSettingsService,
 				$this->createMock(\OCP\Files\IRootFolder::class),
 				$this->createMock(\OCP\TaskProcessing\IManager::class),
+				$this->createMock(\Psr\Log\LoggerInterface::class),
 			),
 			$this->createMock(\OCP\Notification\IManager::class),
 			\OCP\Server::get(QuotaRuleService::class),

--- a/tests/unit/Quota/QuotaTest.php
+++ b/tests/unit/Quota/QuotaTest.php
@@ -93,6 +93,7 @@ class QuotaTest extends TestCase {
 				$this->openAiSettingsService,
 				$this->createMock(\OCP\Files\IRootFolder::class),
 				$this->createMock(\OCP\TaskProcessing\IManager::class),
+				$this->createMock(LoggerInterface::class),
 			),
 			$this->notificationManager,
 			\OCP\Server::get(QuotaRuleService::class),

--- a/tests/unit/Service/ServiceOverrideTest.php
+++ b/tests/unit/Service/ServiceOverrideTest.php
@@ -96,6 +96,7 @@ class ServiceOverrideTest extends TestCase {
 				$this->openAiSettingsService,
 				$this->createMock(\OCP\Files\IRootFolder::class),
 				$this->createMock(\OCP\TaskProcessing\IManager::class),
+				$this->createMock(\Psr\Log\LoggerInterface::class),
 			),
 			$this->createMock(\OCP\Notification\IManager::class),
 			\OCP\Server::get(QuotaRuleService::class),


### PR DESCRIPTION
Uses the same method as assistant for parsing rtf and pdf (pdf portion is just a fallback) into text. Needed to add the same dependencies also.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
