### PR TITLE
Fix: empty tool sometimes causes problems for some backends

### DIFF
--- a/lib/Service/OpenAiAPIService.php
+++ b/lib/Service/OpenAiAPIService.php
@@ -842,7 +842,8 @@ class OpenAiAPIService {
 			$params['max_tokens'] = $maxTokens;
 		}
 
-		if ($tools !== null) {
+		// IONOS does not like an empty tool array
+		if ($tools !== null && count($tools) > 0) {
 			$params['tools'] = $tools;
 		}
 		if ($userId !== null && $this->isUsingOpenAi()) {

--- a/psalm.xml
+++ b/psalm.xml
@@ -8,6 +8,7 @@
 	errorLevel="4"
 	findUnusedBaselineEntry="true"
 	findUnusedCode="false"
+	findUnusedIssueHandlerSuppression="false"
 	resolveFromConfigFile="true"
 	ensureOverrideAttribute="false"
 	phpVersion="8.3"


### PR DESCRIPTION
IONOS will refuse an llm request if the tool array is empty.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
