### PR TITLE
fix: use max tokens parameter everywhere

### DIFF
--- a/lib/TaskProcessing/EmojiProvider.php
+++ b/lib/TaskProcessing/EmojiProvider.php
@@ -78,7 +78,7 @@ class EmojiProvider implements ISynchronousProvider {
 	public function getOptionalInputShapeDefaults(): array {
 		$adminModel = $this->openAiSettingsService->getAdminDefaultCompletionModelId();
 		return [
-			'max_tokens' => 100,
+			'max_tokens' => $this->openAiSettingsService->getMaxTokens(),
 			'model' => $adminModel,
 		];
 	}

--- a/lib/TaskProcessing/HeadlineProvider.php
+++ b/lib/TaskProcessing/HeadlineProvider.php
@@ -78,7 +78,7 @@ class HeadlineProvider implements ISynchronousProvider {
 	public function getOptionalInputShapeDefaults(): array {
 		$adminModel = $this->openAiSettingsService->getAdminDefaultCompletionModelId();
 		return [
-			'max_tokens' => 100,
+			'max_tokens' => $this->openAiSettingsService->getMaxTokens(),
 			'model' => $adminModel,
 		];
 	}


### PR DESCRIPTION
For thinking models limiting the max tokens does not work as thinking tokens are counted breaking these providers.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI (N/A)
